### PR TITLE
Fix: Remove extra white space on the right by adding w-full to QRTool

### DIFF
--- a/src/components/QRTool.tsx
+++ b/src/components/QRTool.tsx
@@ -155,7 +155,7 @@ export default function QRTool({ initialConfig }: { initialConfig?: Partial<QRCo
   };
 
   return (
-    <div className={`${isDarkMode ? 'dark' : ''} h-full`}>
+    <div className={`${isDarkMode ? 'dark' : ''} h-full w-full`}>
       <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col md:flex-row transition-colors duration-300">
         {/* Sidebar Controls */}
         <div className="w-full md:w-[480px] bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-800 h-auto md:h-screen overflow-y-auto flex flex-col shadow-xl z-10 transition-colors duration-300">


### PR DESCRIPTION
The main application component `QRTool` was not taking up the full width of the viewport, causing the underlying layout background to show as white space on the right side. This change adds the `w-full` class to the root container of `QRTool` to ensure it stretches to fill the available width.