### PR TITLE
fix(layout): enable scrolling on mobile devices

### DIFF
--- a/src/layouts/LayoutDefault.tsx
+++ b/src/layouts/LayoutDefault.tsx
@@ -3,7 +3,7 @@ import './index.css';
 
 export default function LayoutDefault({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-screen overflow-hidden bg-slate-50 dark:bg-slate-900 text-slate-700 dark:text-slate-200 antialiased font-sans">
+    <div className="flex h-screen overflow-auto md:overflow-hidden bg-slate-50 dark:bg-slate-900 text-slate-700 dark:text-slate-200 antialiased font-sans">
         {children}
     </div>
   );


### PR DESCRIPTION
Currently, the `LayoutDefault` applies `h-screen overflow-hidden` unconditionally. This prevents scrolling on mobile devices where the content (stacked vertically) often exceeds the viewport height.

This change updates the layout to use `overflow-auto` by default (for mobile) and `overflow-hidden` only on `md` screens and larger (where the desktop layout handles internal scrolling).

Fixes issue where users cannot scroll on mobile.