### PR TITLE
Force QR code canvas to maintain 1:1 aspect ratio

### DIFF
--- a/src/components/QRCanvas.tsx
+++ b/src/components/QRCanvas.tsx
@@ -275,7 +275,8 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
     <div className={className} style={{ aspectRatio: '1/1' }}>
       <canvas
         ref={canvasRef}
-        className="w-full h-full"
+        className="w-full h-auto block"
+        style={{ aspectRatio: '1/1' }}
         role="img"
         aria-label={ariaLabel}
       />


### PR DESCRIPTION
Updated the QRCanvas component to use `h-auto` and an inline `aspect-ratio: 1/1` style. This ensures the QR code is always rendered as a square, preventing distortion when the parent container has different dimensions.