### PR TITLE
Fix: clear password in WiFi QR code string when encryption is nopass

### DIFF
--- a/src/components/InputPanel.test.tsx
+++ b/src/components/InputPanel.test.tsx
@@ -98,6 +98,24 @@ describe('InputPanel Component', () => {
     expect(mockOnChange).toHaveBeenLastCalledWith({ value: expectedValue });
   });
 
+  it('clears password in WIFI string when encryption is changed to nopass after setting password', () => {
+    renderPanel({ type: QRType.WIFI });
+
+    // 1. Enter a password with WPA (default)
+    const passwordInput = screen.getByLabelText('Password');
+    fireEvent.change(passwordInput, { target: { value: 'secret123' } });
+
+    // 2. Change encryption to nopass
+    const encryptionSelect = screen.getByLabelText('Encryption');
+    fireEvent.change(encryptionSelect, { target: { value: 'nopass' } });
+
+    // 3. Verify the output string does NOT contain the password
+    const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
+    expect(lastCall.value).not.toContain('P:secret123');
+    // It should have an empty password field
+    expect(lastCall.value).toContain('P:;');
+  });
+
   it('formats Email correctly', () => {
       renderPanel({ type: QRType.EMAIL });
 

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -44,7 +44,8 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
     if (newData.encryption === 'WPA2-EAP') {
         wifiString = `WIFI:T:WPA2-EAP;S:${newData.ssid};I:${newData.eapIdentity};P:${newData.password};H:${newData.hidden};;`;
     } else {
-        wifiString = `WIFI:T:${newData.encryption};S:${newData.ssid};P:${newData.password};H:${newData.hidden};;`;
+        const password = newData.encryption === 'nopass' ? '' : newData.password;
+        wifiString = `WIFI:T:${newData.encryption};S:${newData.ssid};P:${password};H:${newData.hidden};;`;
     }
     onChange({ value: wifiString });
   };


### PR DESCRIPTION
- Modified `InputPanel.tsx` to explicitly set the password to an empty string when generating the WiFi configuration string if encryption is `nopass`.
- Added a regression test case in `InputPanel.test.tsx` to verify that the password is correctly omitted from the generated string when switching from a password-protected encryption type to `nopass`.