### PR TITLE
feat(ui): ensure QR code is visible above the fold on mobile

### DIFF
--- a/src/components/QRTool.tsx
+++ b/src/components/QRTool.tsx
@@ -156,7 +156,7 @@ export default function QRTool({ initialConfig }: { initialConfig?: Partial<QRCo
 
   return (
     <div className={`${isDarkMode ? 'dark' : ''} h-full w-full`}>
-      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col md:flex-row transition-colors duration-300">
+      <div className="min-h-screen bg-slate-50 dark:bg-slate-950 flex flex-col-reverse md:flex-row transition-colors duration-300">
         {/* Sidebar Controls */}
         <div className="w-full md:w-[480px] bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-800 h-auto md:h-screen overflow-y-auto flex flex-col shadow-xl z-10 transition-colors duration-300">
           <div className="p-6 border-b border-slate-100 dark:border-slate-800 bg-white dark:bg-slate-900 sticky top-0 z-20 flex justify-between items-center transition-colors duration-300">
@@ -202,7 +202,7 @@ export default function QRTool({ initialConfig }: { initialConfig?: Partial<QRCo
         </div>
 
         {/* Preview Area */}
-        <div className="flex-1 bg-slate-50 dark:bg-slate-950 flex flex-col items-center justify-center p-8 relative overflow-hidden transition-colors duration-300">
+        <div className="flex-1 bg-slate-50 dark:bg-slate-950 flex flex-col items-center justify-center p-4 md:p-8 relative overflow-hidden transition-colors duration-300">
            {/* Background Decoration */}
            <div className="absolute inset-0 pointer-events-none opacity-40 dark:opacity-20">
                <div className="absolute top-0 left-0 w-96 h-96 bg-teal-200 dark:bg-teal-900 rounded-full blur-3xl -translate-x-1/2 -translate-y-1/2 transition-colors duration-300"></div>


### PR DESCRIPTION
Updated the `QRTool` component to use `flex-col-reverse` on mobile layouts. This reorders the display so the QR code preview appears visually above the controls and header, addressing user feedback about visibility without scrolling. Desktop layout (`md:flex-row`) is preserved. Also reduced preview padding on mobile to optimize space.