### PR TITLE
Fix: Add valid robots.txt for SEO compliance

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /


### PR DESCRIPTION
Creates a standard robots.txt file in the public directory to resolve the SEO audit failure. This ensures that search engine crawlers can correctly access and index the application, rather than receiving an invalid HTML response or 404.

* **public/robots.txt**: Added file with permissive crawling rules (`User-agent: *`, `Allow: /`).