### PR TITLE
Fix WCAG color contrast failures in Dashboard components

### DIFF
--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -120,7 +120,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
             }`}
           >
             <item.icon className="w-4 h-4" />
-            <span className="truncate w-full text-center">{item.label}</span>
+            <span className="truncate w-full text-center text-slate-700 dark:text-slate-400">{item.label}</span>
           </button>
         ))}
       </div>

--- a/src/components/QRTool.tsx
+++ b/src/components/QRTool.tsx
@@ -188,14 +188,14 @@ export default function QRTool({ initialConfig }: { initialConfig?: Partial<QRCo
 
           <div className="p-6 space-y-8 pb-24">
             <section>
-              <h2 className="text-xs uppercase tracking-wider text-slate-400 dark:text-slate-500 font-bold mb-4">Content</h2>
+              <h2 className="text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400 font-bold mb-4">Content</h2>
               <InputPanel config={config} onChange={handleConfigChange} />
             </section>
 
             <div className="h-px bg-slate-100 dark:bg-slate-800" />
 
             <section>
-              <h2 className="text-xs uppercase tracking-wider text-slate-400 dark:text-slate-500 font-bold mb-4">Appearance</h2>
+              <h2 className="text-xs uppercase tracking-wider text-slate-600 dark:text-slate-400 font-bold mb-4">Appearance</h2>
               <StyleControls config={config} onChange={handleConfigChange} />
             </section>
           </div>


### PR DESCRIPTION
Updated section headers in `QRTool` from `text-slate-400` to `text-slate-600` (light mode) and `dark:text-slate-400` (dark mode) to meet WCAG AA contrast requirements.

Updated grid labels in `InputPanel` to explicitly use `text-slate-700` (light mode) and `dark:text-slate-400` (dark mode), ensuring sufficient contrast against the button background.

Verified changes with computed style checks and unit tests.