### PR TITLE
feat(a11y): add main landmark to LayoutDefault

### DIFF
--- a/src/layouts/LayoutDefault.test.tsx
+++ b/src/layouts/LayoutDefault.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import LayoutDefault from './LayoutDefault';
+
+describe('LayoutDefault', () => {
+  it('renders children correctly', () => {
+    render(
+      <LayoutDefault>
+        <div data-testid="child-content">Child Content</div>
+      </LayoutDefault>
+    );
+    expect(screen.getByTestId('child-content')).toBeInTheDocument();
+  });
+
+  it('contains a main landmark', () => {
+    render(
+      <LayoutDefault>
+        <div>Content</div>
+      </LayoutDefault>
+    );
+    // This expects to find an element with role="main"
+    // Using queryByRole to avoid throwing immediately if I want to assert it's missing first,
+    // but usually we want to test for presence.
+    const main = screen.getByRole('main');
+    expect(main).toBeInTheDocument();
+  });
+});

--- a/src/layouts/LayoutDefault.tsx
+++ b/src/layouts/LayoutDefault.tsx
@@ -14,8 +14,8 @@ import './index.css';
  */
 export default function LayoutDefault({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex h-screen overflow-auto md:overflow-hidden bg-slate-50 dark:bg-slate-900 text-slate-700 dark:text-slate-200 antialiased font-sans">
+    <main className="flex h-screen overflow-auto md:overflow-hidden bg-slate-50 dark:bg-slate-900 text-slate-700 dark:text-slate-200 antialiased font-sans">
         {children}
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
Replaces the generic wrapper div in LayoutDefault with a `<main>` tag to ensure the document has a main landmark, satisfying accessibility requirements (WCAG/ARIA) and resolving the 'Document does not have a main landmark' audit error.

Includes a new unit test in `src/layouts/LayoutDefault.test.tsx` to verify the presence of the main landmark.