### PR TITLE
feat: add Payment QR code type for crypto URIs

### DIFF
--- a/src/components/InputPanel.test.tsx
+++ b/src/components/InputPanel.test.tsx
@@ -199,4 +199,35 @@ describe('InputPanel Component', () => {
 
       expect(mockOnChange).toHaveBeenLastCalledWith({ value: expectedVCard });
   });
+
+  it('formats Payment (Crypto) correctly', () => {
+    renderPanel({ type: QRType.PAYMENT });
+
+    const addressInput = screen.getByLabelText('Receiver Address');
+    fireEvent.change(addressInput, { target: { value: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' } });
+
+    // Default is Bitcoin
+    expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' });
+
+    // Add amount
+    const amountInput = screen.getByLabelText('Amount (Optional)');
+    fireEvent.change(amountInput, { target: { value: '0.005' } });
+    expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa?amount=0.005' });
+
+    // Add label
+    const labelInput = screen.getByLabelText('Label / Note (Optional)');
+    fireEvent.change(labelInput, { target: { value: 'Donation for Coffee' } });
+    expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'bitcoin:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa?amount=0.005&label=Donation%20for%20Coffee' });
+
+    // Change Network to Ethereum
+    const networkSelect = screen.getByLabelText('Currency / Network');
+    fireEvent.change(networkSelect, { target: { value: 'ethereum' } });
+    // State persists, so params are re-applied to new network scheme
+    expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'ethereum:1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa?amount=0.005&label=Donation%20for%20Coffee' });
+
+    // Change to Custom
+    fireEvent.change(networkSelect, { target: { value: 'custom' } });
+    // Should output raw address/string
+    expect(mockOnChange).toHaveBeenLastCalledWith({ value: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' });
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export enum QRType {
   VCARD = 'VCARD',
   PHONE = 'PHONE',
   SMS = 'SMS',
+  PAYMENT = 'PAYMENT',
 }
 
 /**
@@ -129,4 +130,18 @@ export interface SmsData {
   number: string;
   /** The text message body. */
   message: string;
+}
+
+/**
+ * Data structure for Payment information (Crypto).
+ */
+export interface PaymentData {
+  /** The cryptocurrency network (e.g. bitcoin, ethereum). */
+  network: string;
+  /** The wallet address. */
+  address: string;
+  /** The amount to request (optional). */
+  amount: string;
+  /** Label or message for the transaction (optional). */
+  label: string;
 }


### PR DESCRIPTION
Adds a new `PAYMENT` type to the QR generator, supporting generic cryptocurrency payment URIs (Bitcoin, Ethereum, Solana, Litecoin) and custom addresses.

- Updates `QRType` enum in `src/types.ts` to include `PAYMENT`.
- Adds `PaymentData` interface in `src/types.ts`.
- Updates `InputPanel.tsx` to include the Payment type selector and input fields.
- Implements URI generation logic for crypto payments.
- Adds unit tests in `src/components/InputPanel.test.tsx`.