### PR TITLE
Add Minnesota sports team color presets

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,4 +47,7 @@ export const PRESET_COLORS = [
   { bg: '#fff1f2', fg: '#9f1239', eye: '#881337', label: 'Rose' },
   { bg: '#faf5ff', fg: '#6b21a8', eye: '#581c87', label: 'Purple' },
   { bg: '#27272a', fg: '#e4e4e7', eye: '#facc15', label: 'Cyber' },
+  { bg: '#0c2340', fg: '#ffffff', eye: '#78be20', label: 'Timberwolves' },
+  { bg: '#ffffff', fg: '#154734', eye: '#a6192e', label: 'Wild' },
+  { bg: '#4f2683', fg: '#ffffff', eye: '#ffc62f', label: 'Vikings' },
 ];

--- a/src/tests/VerifyColors.test.tsx
+++ b/src/tests/VerifyColors.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { PRESET_COLORS } from '../constants';
+
+describe('Color Presets Verification', () => {
+  it('should include Minnesota Timberwolves colors', () => {
+    const wolves = PRESET_COLORS.find(c => c.label === 'Timberwolves');
+    expect(wolves).toBeDefined();
+    expect(wolves).toEqual({
+      bg: '#0c2340',
+      fg: '#ffffff',
+      eye: '#78be20',
+      label: 'Timberwolves'
+    });
+  });
+
+  it('should include Minnesota Wild colors', () => {
+    const wild = PRESET_COLORS.find(c => c.label === 'Wild');
+    expect(wild).toBeDefined();
+    expect(wild).toEqual({
+      bg: '#ffffff',
+      fg: '#154734',
+      eye: '#a6192e',
+      label: 'Wild'
+    });
+  });
+
+  it('should include Minnesota Vikings colors', () => {
+    const vikings = PRESET_COLORS.find(c => c.label === 'Vikings');
+    expect(vikings).toBeDefined();
+    expect(vikings).toEqual({
+      bg: '#4f2683',
+      fg: '#ffffff',
+      eye: '#ffc62f',
+      label: 'Vikings'
+    });
+  });
+});


### PR DESCRIPTION
Added three new color presets to the application corresponding to:
- Minnesota Timberwolves
- Minnesota Wild
- Minnesota Vikings

These presets are available in `src/constants.ts` and verified with a new test `src/tests/VerifyColors.test.tsx`.