### PR TITLE
fix(seo): improve accessibility contrast ratios for text

### DIFF
--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -422,7 +422,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                  </div>
 
                  <div className="pt-2 border-t border-slate-100 dark:border-slate-800">
-                    <label className="block text-xs font-bold text-slate-400 dark:text-slate-500 mb-2">Address</label>
+                    <label className="block text-xs font-bold text-slate-600 dark:text-slate-400 mb-2">Address</label>
                     <div className="space-y-3">
                         <input aria-label="Street" type="text" placeholder="Street" value={vCardData.street} onChange={(e) => handleVCardChange({ street: e.target.value })} className={inputClasses} />
                         <div className="grid grid-cols-2 gap-3">

--- a/src/components/QRTool.tsx
+++ b/src/components/QRTool.tsx
@@ -165,7 +165,7 @@ export default function QRTool({ initialConfig }: { initialConfig?: Partial<QRCo
                 <QrCode className="w-6 h-6" />
                 <h1 className="text-xl font-bold tracking-tight text-slate-700 dark:text-slate-100">QRCraftly</h1>
               </div>
-              <p className="text-sm text-slate-500 dark:text-slate-400">Design beautiful QR codes in seconds.</p>
+              <p className="text-sm text-slate-600 dark:text-slate-400">Design beautiful QR codes in seconds.</p>
             </div>
             
             <div className="flex gap-2">

--- a/src/components/StyleControls.tsx
+++ b/src/components/StyleControls.tsx
@@ -243,7 +243,7 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
                  <Upload className="w-5 h-5" />
             </div>
             <span className="text-sm font-medium">Upload Logo</span>
-            <span className="text-xs text-slate-400 dark:text-slate-500 mt-1">PNG, JPG (Square recommended)</span>
+            <span className="text-xs text-slate-600 dark:text-slate-400 mt-1">PNG, JPG (Square recommended)</span>
           </div>
         ) : (
             <div className="bg-slate-50 dark:bg-slate-800/50 rounded-xl p-4 border border-slate-200 dark:border-slate-700 space-y-5">


### PR DESCRIPTION
- Updated text colors in `StyleControls.tsx`, `QRTool.tsx`, and `InputPanel.tsx` to meet WCAG AA standards.
- Replaced `text-slate-400` with `text-slate-600` (or `text-slate-500` where appropriate) for light mode.
- Replaced `dark:text-slate-500` with `dark:text-slate-400` for dark mode.
- Verified contrast ratios (e.g., slate-600 on white is 7.58:1, slate-400 on slate-900 is 6.96:1).