### PR TITLE
Update default URL placeholder to qrcraftly.com

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ import { QRStyle, QRType } from './types';
  * Used to initialize the application state.
  */
 export const DEFAULT_CONFIG = {
-  value: 'https://google.com',
+  value: 'https://qrcraftly.com',
   type: QRType.URL,
   fgColor: '#000000',
   bgColor: '#ffffff',


### PR DESCRIPTION
Changed the default initial value for the QR code URL from 'https://google.com' to 'https://qrcraftly.com' in src/constants.ts to better reflect the product brand. Verified with frontend tests and manual check.