### PR TITLE
fix(InputPanel): omit password field for nopass WiFi encryption

### DIFF
--- a/src/components/InputPanel.test.tsx
+++ b/src/components/InputPanel.test.tsx
@@ -94,7 +94,7 @@ describe('InputPanel Component', () => {
     const ssidInput = screen.getByLabelText('Network Name (SSID)');
     fireEvent.change(ssidInput, { target: { value: 'OpenWiFi' } });
 
-    const expectedValue = `WIFI:T:nopass;S:OpenWiFi;P:;H:false;;`;
+    const expectedValue = `WIFI:T:nopass;S:OpenWiFi;H:false;;`;
     expect(mockOnChange).toHaveBeenLastCalledWith({ value: expectedValue });
   });
 
@@ -139,8 +139,8 @@ describe('InputPanel Component', () => {
     // 3. Verify the output string does NOT contain the password
     const lastCall = mockOnChange.mock.calls[mockOnChange.mock.calls.length - 1][0];
     expect(lastCall.value).not.toContain('P:secret123');
-    // It should have an empty password field
-    expect(lastCall.value).toContain('P:;');
+    // It should NOT have a password field at all
+    expect(lastCall.value).not.toContain('P:');
   });
 
   it('formats Email correctly', () => {

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -82,9 +82,12 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
         const password = escapeWifiString(newData.password);
         wifiString = `WIFI:T:WPA2-EAP;S:${ssid};I:${identity};P:${password};H:${hidden};;`;
     } else {
-        const rawPassword = newData.encryption === 'nopass' ? '' : newData.password;
-        const password = escapeWifiString(rawPassword);
-        wifiString = `WIFI:T:${newData.encryption};S:${ssid};P:${password};H:${hidden};;`;
+        if (newData.encryption === 'nopass') {
+            wifiString = `WIFI:T:${newData.encryption};S:${ssid};H:${hidden};;`;
+        } else {
+            const password = escapeWifiString(newData.password);
+            wifiString = `WIFI:T:${newData.encryption};S:${ssid};P:${password};H:${hidden};;`;
+        }
     }
     onChange({ value: wifiString });
   };


### PR DESCRIPTION
Updates the `InputPanel` component to correctly format the WiFi configuration string when the encryption type is set to 'nopass'. Previously, it generated `P:;`, which included an empty password field. The fix ensures that the `P` field is completely omitted, adhering to standard practices for open networks and fulfilling project requirements.

Existing tests were updated to reflect this corrected behavior.