### PR TITLE
I fixed data corruption in SMS and TEL QR codes by sanitizing colons.

### DIFF
--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -135,7 +135,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
   const handlePhoneChange = (updates: Partial<PhoneData>) => {
       const newData = { ...phoneData, ...updates };
       setPhoneData(newData);
-      const cleanNumber = newData.number.replace(/\s+/g, '');
+      const cleanNumber = newData.number.replace(/[\s:]+/g, '');
       onChange({ value: `tel:${cleanNumber}` });
   };
 
@@ -146,7 +146,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
   const handleSmsChange = (updates: Partial<SmsData>) => {
       const newData = { ...smsData, ...updates };
       setSmsData(newData);
-      const cleanNumber = newData.number.replace(/\s+/g, '');
+      const cleanNumber = newData.number.replace(/[\s:]+/g, '');
       onChange({ value: `smsto:${cleanNumber}:${newData.message}` });
   };
 


### PR DESCRIPTION
I updated `InputPanel.tsx` to strip colons from phone number inputs for both SMS and Phone QR types. This prevents ambiguous `smsto:` strings (e.g. `smsto:123:456:message`) and invalid `tel:` URIs.

I verified the fix with a new test case in `src/components/InputPanel_SMSColon.test.tsx`, which I removed after testing.