### PR TITLE
fix(accessibility): add accessible label to border toggle

### DIFF
--- a/src/components/StyleControls.tsx
+++ b/src/components/StyleControls.tsx
@@ -115,6 +115,7 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
             <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">Border</h3>
             <div className="flex items-center">
                 <label className="relative inline-flex items-center cursor-pointer">
+                    <span className="sr-only">Enable Border</span>
                     <input
                         type="checkbox"
                         className="sr-only peer"


### PR DESCRIPTION
Adds a `span` with `sr-only` class containing "Enable Border" to the border toggle checkbox in `StyleControls.tsx`. This ensures that screen readers can announce the purpose of the control, addressing an accessibility violation where the form element lacked an associated label.