### PR TITLE
fix(a11y): convert upload logo dropzone to a button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Accessibility of Custom File Inputs
+**Learning:** Custom file inputs using `div` with `onClick` are a common accessibility trap. They completely exclude keyboard users.
+**Action:** Always use `<button type="button">` for custom triggers, even if they wrap complex content. It provides native keyboard focus and activation without extra aria-role or key handler code.

--- a/src/components/StyleControls.tsx
+++ b/src/components/StyleControls.tsx
@@ -422,16 +422,17 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
         </div>
        
         {!config.logoUrl ? (
-          <div 
+          <button
+            type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="border-2 border-dashed border-slate-200 dark:border-slate-700 rounded-xl p-6 flex flex-col items-center justify-center text-slate-500 dark:text-slate-400 hover:bg-teal-50 dark:hover:bg-teal-900/10 hover:border-teal-400 dark:hover:border-teal-600 hover:text-teal-700 dark:hover:text-teal-400 transition-all cursor-pointer group"
+            className="w-full border-2 border-dashed border-slate-200 dark:border-slate-700 rounded-xl p-6 flex flex-col items-center justify-center text-slate-500 dark:text-slate-400 hover:bg-teal-50 dark:hover:bg-teal-900/10 hover:border-teal-400 dark:hover:border-teal-600 hover:text-teal-700 dark:hover:text-teal-400 transition-all cursor-pointer group"
           >
             <div className="w-10 h-10 bg-slate-100 dark:bg-slate-800 rounded-full flex items-center justify-center mb-2 group-hover:bg-teal-100 dark:group-hover:bg-teal-900/30 transition-colors">
                  <Upload className="w-5 h-5" />
             </div>
             <span className="text-sm font-medium">Upload Logo</span>
             <span className="text-xs text-slate-600 dark:text-slate-400 mt-1">PNG, JPG (Square recommended)</span>
-          </div>
+          </button>
         ) : (
             <div className="bg-slate-50 dark:bg-slate-800/50 rounded-xl p-4 border border-slate-200 dark:border-slate-700 space-y-5">
                 <div className="flex items-center gap-4">


### PR DESCRIPTION
Replaces the non-semantic `div` with an `onClick` handler in the `StyleControls` component with a semantic `<button>` element. This ensures the "Upload Logo" feature is accessible to keyboard and screen reader users, while preserving the existing visual design and functionality.

Changes:
- src/components/StyleControls.tsx: Replace `div` with `button type="button"`.
- .Jules/palette.md: Record accessibility learning regarding custom file inputs.