### PR TITLE
feat(seo): add BreadcrumbList structured data

### DIFF
--- a/src/layouts/Head.tsx
+++ b/src/layouts/Head.tsx
@@ -18,22 +18,57 @@ export default function HeadDefault() {
   const pageContext = usePageContext();
   // Ensure we don't end up with double slashes if urlPathname is just '/'
   const path = pageContext.urlPathname === '/' ? '' : pageContext.urlPathname;
-  const canonicalUrl = `https://qrcraftly.com${path}`;
+
+  // Define domain constant to ensure consistency
+  const DOMAIN = "https://qrcraftly.com";
+  const canonicalUrl = `${DOMAIN}${path}`;
 
   const schemaData = {
     "@context": "https://schema.org",
     "@type": "WebSite",
     "name": "QRCraftly",
-    "url": "https://qrcraftly.com",
+    "url": DOMAIN,
     "description": "Free, secure, and client-side QR code generator with zero-knowledge architecture.",
     "publisher": {
       "@type": "Organization",
       "name": "QRCraftly",
       "logo": {
         "@type": "ImageObject",
-        "url": "https://qrcraftly.com/favicon.png"
+        "url": `${DOMAIN}/favicon.png`
       }
     }
+  };
+
+  // Breadcrumb Schema Generation
+  const breadcrumbItems = [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": `${DOMAIN}/`
+    }
+  ];
+
+  if (pageContext.urlPathname === '/about') {
+    breadcrumbItems.push({
+      "@type": "ListItem",
+      "position": 2,
+      "name": "About",
+      "item": `${DOMAIN}/about`
+    });
+  } else if (pageContext.urlPathname === '/wifi-qr-code') {
+    breadcrumbItems.push({
+      "@type": "ListItem",
+      "position": 2,
+      "name": "WiFi QR Code",
+      "item": `${DOMAIN}/wifi-qr-code`
+    });
+  }
+
+  const breadcrumbSchema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": breadcrumbItems
   };
 
   return (
@@ -47,6 +82,7 @@ export default function HeadDefault() {
 
       {/* Global Structured Data */}
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(schemaData) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }} />
 
       {/* Canonical URL */}
       <link rel="canonical" href={canonicalUrl} />
@@ -59,11 +95,11 @@ export default function HeadDefault() {
         TODO: Replace with a dedicated social share image (1200x630px) when available.
         Current fallback is favicon.png to ensure *some* image appears.
       */}
-      <meta property="og:image" content="https://qrcraftly.com/favicon.png" />
+      <meta property="og:image" content={`${DOMAIN}/favicon.png`} />
 
       {/* Social Signals (Twitter) */}
       <meta name="twitter:card" content="summary" />
-      <meta name="twitter:image" content="https://qrcraftly.com/favicon.png" />
+      <meta name="twitter:image" content={`${DOMAIN}/favicon.png`} />
 
       <link rel="icon" type="image/png" href="/favicon.png" />
       <link rel="apple-touch-icon" href="/favicon.png" />


### PR DESCRIPTION
Adds JSON-LD structured data for Breadcrumbs to `HeadDefault`. This improves search engine understanding of the site structure and enables rich snippets in search results. Specifically targets `/`, `/about`, and `/wifi-qr-code` routes.