### PR TITLE
feat: Add HowTo schema to WiFi QR Code page

### DIFF
--- a/src/pages/wifi-qr-code/+Page.tsx
+++ b/src/pages/wifi-qr-code/+Page.tsx
@@ -19,17 +19,43 @@ export default function Page() {
 
   const schemaData = {
     "@context": "https://schema.org",
-    "@type": "WebApplication",
-    "name": "WiFi QR Code Generator",
-    "url": "https://qrcraftly.com/wifi-qr-code",
-    "applicationCategory": "Utilities",
-    "operatingSystem": "All",
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "USD"
-    },
-    "featureList": "Generate WiFi Access QR Codes, WPA/WPA2 Support, Hidden SSID Support"
+    "@graph": [
+      {
+        "@type": "WebApplication",
+        "name": "WiFi QR Code Generator",
+        "url": "https://qrcraftly.com/wifi-qr-code",
+        "applicationCategory": "Utilities",
+        "operatingSystem": "All",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "featureList": "Generate WiFi Access QR Codes, WPA/WPA2 Support, Hidden SSID Support"
+      },
+      {
+        "@type": "HowTo",
+        "name": "How to create a WiFi QR Code",
+        "description": "Generate a QR code that allows guests to connect to your WiFi network instantly without typing a password.",
+        "step": [
+          {
+            "@type": "HowToStep",
+            "name": "Enter Network Details",
+            "text": "Input your WiFi network name (SSID) and select the encryption type (usually WPA/WPA2)."
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Enter Password",
+            "text": "Type your WiFi password. Your password is processed locally in your browser and never sent to any server."
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Download QR Code",
+            "text": "Click the Download button to save your WiFi QR code as an image."
+          }
+        ]
+      }
+    ]
   };
 
   return (


### PR DESCRIPTION
This commit adds `HowTo` structured data to the WiFi QR Code landing page. This schema describes the steps to generate a WiFi QR code (Network Details, Password, Download), increasing the likelihood of rich results in search engines for "how to" queries.

The implementation uses the JSON-LD `@graph` syntax to correctly combine the existing `WebApplication` schema with the new `HowTo` schema. No visual changes were made to the page.

Test Plan:
- Verified `npm run build` output contains valid JSON-LD in `dist/client/wifi-qr-code/index.html`.
- Ran `npm test` to ensure no regressions.