### PR TITLE
feat(a11y): improve accessibility of StyleControls component

### DIFF
--- a/src/components/StyleControls.tsx
+++ b/src/components/StyleControls.tsx
@@ -274,6 +274,8 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
           {PATTERNS.map((pattern) => (
             <button
               key={pattern.id}
+              type="button"
+              aria-pressed={config.style === pattern.id}
               onClick={() => onChange({ style: pattern.id })}
               className={`flex flex-col items-center justify-center p-3 rounded-xl border-2 transition-all ${
                 config.style === pattern.id
@@ -346,6 +348,8 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
           {PRESET_COLORS.map((preset, idx) => (
             <button
               key={idx}
+              type="button"
+              aria-label={preset.label}
               onClick={() => onChange({ fgColor: preset.fg, bgColor: preset.bg, eyeColor: preset.eye })}
               className="group relative w-10 h-10 rounded-lg shadow-sm hover:scale-110 transition-transform duration-200 ring-1 ring-slate-200 dark:ring-slate-700 overflow-hidden"
               title={preset.label}
@@ -530,6 +534,9 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
       {/* Advanced Mode */}
       <div className="border-t border-slate-200 dark:border-slate-700 pt-5">
         <button
+          type="button"
+          aria-expanded={showAdvanced}
+          aria-controls="advanced-panel"
           onClick={() => setShowAdvanced(!showAdvanced)}
           className="flex items-center justify-between w-full text-left"
         >
@@ -542,7 +549,7 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
         </button>
 
         {showAdvanced && (
-          <div className="mt-4 space-y-4">
+          <div id="advanced-panel" className="mt-4 space-y-4">
              <div>
                 <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-2">Error Correction Level</label>
                 <div className="grid grid-cols-2 gap-2">

--- a/src/components/StyleControls_Accessibility.test.tsx
+++ b/src/components/StyleControls_Accessibility.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import StyleControls from './StyleControls';
+import { DEFAULT_CONFIG } from '../constants';
+import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+
+describe('StyleControls Accessibility', () => {
+  const mockOnChange = vi.fn();
+
+  it('Advanced Mode toggle has correct ARIA attributes', async () => {
+    const user = userEvent.setup();
+    render(<StyleControls config={DEFAULT_CONFIG} onChange={mockOnChange} />);
+
+    const toggle = screen.getByText('Advanced Mode').closest('button');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', 'advanced-panel');
+
+    // Click to expand
+    if (toggle) await user.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    const panel = document.getElementById('advanced-panel');
+    expect(panel).toBeInTheDocument();
+  });
+
+  it('Pattern style buttons have aria-pressed', () => {
+    render(<StyleControls config={DEFAULT_CONFIG} onChange={mockOnChange} />);
+
+    // Find a pattern button (e.g., Standard)
+    const buttons = screen.getAllByRole('button');
+    // We can't easily select by role='button' only because there are many.
+    // But we know pattern buttons are inside "Pattern Style" section.
+    // Let's assume the button with the current style (Standard) is pressed.
+
+    // We can look for the button containing "Standard" text
+    const standardBtn = screen.getByText(/Standard/).closest('button');
+    expect(standardBtn).toHaveAttribute('aria-pressed', 'true');
+
+    const otherBtn = screen.getByText(/Swiss Dot/).closest('button');
+    expect(otherBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('Color preset buttons have aria-label', () => {
+    render(<StyleControls config={DEFAULT_CONFIG} onChange={mockOnChange} />);
+
+    // PRESET_COLORS constant has labels like "Classic", "Slate", etc.
+    const classicBtn = screen.getByLabelText('Classic');
+    expect(classicBtn).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Add `aria-pressed` to pattern style buttons for state indication
- Add `aria-label` to color preset buttons for screen reader support
- Add `aria-expanded` and `aria-controls` to Advanced Mode toggle
- Add `type="button"` to all interactive buttons to prevent form submission
- Add dedicated accessibility test suite `StyleControls_Accessibility.test.tsx`