### PR TITLE
feat: Add HowTo schema to WiFi QR Code page

### DIFF
--- a/src/pages/wifi-qr-code/+Page.tsx
+++ b/src/pages/wifi-qr-code/+Page.tsx
@@ -19,17 +19,48 @@ export default function Page() {
 
   const schemaData = {
     "@context": "https://schema.org",
-    "@type": "WebApplication",
-    "name": "WiFi QR Code Generator",
-    "url": "https://qrcraftly.com/wifi-qr-code",
-    "applicationCategory": "Utilities",
-    "operatingSystem": "All",
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "USD"
-    },
-    "featureList": "Generate WiFi Access QR Codes, WPA/WPA2 Support, Hidden SSID Support"
+    "@graph": [
+      {
+        "@type": "WebApplication",
+        "name": "WiFi QR Code Generator",
+        "url": "https://qrcraftly.com/wifi-qr-code",
+        "applicationCategory": "Utilities",
+        "operatingSystem": "All",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "featureList": "Generate WiFi Access QR Codes, WPA/WPA2 Support, Hidden SSID Support"
+      },
+      {
+        "@type": "HowTo",
+        "name": "How to Create a WiFi QR Code",
+        "description": "Generate a QR code to share your WiFi network instantly.",
+        "step": [
+          {
+            "@type": "HowToStep",
+            "name": "Enter Network Name",
+            "text": "Input your WiFi SSID (Network Name) into the designated field."
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Enter Password",
+            "text": "Enter your WiFi password. Your data remains local and secure."
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Select Encryption",
+            "text": "Choose your network encryption type (WPA/WPA2 is most common)."
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Download or Share",
+            "text": "Click 'Download' to save the QR code or scan it directly from the screen."
+          }
+        ]
+      }
+    ]
   };
 
   return (

--- a/src/pages/wifi-qr-code/Page.test.tsx
+++ b/src/pages/wifi-qr-code/Page.test.tsx
@@ -21,4 +21,18 @@ describe('WiFi QR Code Page', () => {
     expect(qrTool).toBeInTheDocument();
     expect(qrTool).toHaveTextContent('QRTool with type: WIFI');
   });
+
+  it('renders structured data schema', () => {
+    const { container } = render(<Page />);
+    const script = container.querySelector('script[type="application/ld+json"]');
+    expect(script).toBeInTheDocument();
+    const json = JSON.parse(script?.textContent || '{}');
+    expect(json['@context']).toBe('https://schema.org');
+    expect(json['@graph']).toBeDefined();
+    expect(json['@graph']).toHaveLength(2); // WebApplication and HowTo
+
+    const types = json['@graph'].map((item: any) => item['@type']);
+    expect(types).toContain('WebApplication');
+    expect(types).toContain('HowTo');
+  });
 });


### PR DESCRIPTION
This commit adds `HowTo` structured data to the `wifi-qr-code` page, enabling rich search results for users looking to generate WiFi QR codes. The implementation combines the existing `WebApplication` schema with the new `HowTo` schema using the `@graph` property. It also updates the page test to verify the schema structure.