### PR TITLE
feat(a11y): add aria attributes to advanced mode toggle

### DIFF
--- a/src/components/StyleControls.tsx
+++ b/src/components/StyleControls.tsx
@@ -502,6 +502,8 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
         <button
           onClick={() => setShowAdvanced(!showAdvanced)}
           className="flex items-center justify-between w-full text-left"
+          aria-expanded={showAdvanced}
+          aria-controls="advanced-settings-panel"
         >
           <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">Advanced Mode</span>
           {showAdvanced ? (
@@ -512,7 +514,7 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
         </button>
 
         {showAdvanced && (
-          <div className="mt-4 space-y-4">
+          <div className="mt-4 space-y-4" id="advanced-settings-panel">
              <div>
                 <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-2">Error Correction Level</label>
                 <div className="grid grid-cols-2 gap-2">

--- a/src/components/StyleControls_Accessibility.test.tsx
+++ b/src/components/StyleControls_Accessibility.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import StyleControls from './StyleControls';
+import { DEFAULT_CONFIG } from '../constants';
+
+describe('StyleControls Accessibility', () => {
+  const mockOnChange = vi.fn();
+
+  it('Advanced Mode toggle should have correct aria attributes', () => {
+    render(<StyleControls config={DEFAULT_CONFIG} onChange={mockOnChange} />);
+
+    // Find the Advanced Mode toggle button
+    const advancedToggle = screen.getByRole('button', { name: /Advanced Mode/i });
+
+    // Initial state: not expanded
+    expect(advancedToggle).toHaveAttribute('aria-expanded', 'false');
+    expect(advancedToggle).toHaveAttribute('aria-controls', 'advanced-settings-panel');
+
+    // Click to expand
+    fireEvent.click(advancedToggle);
+
+    // Expect aria-expanded to be true
+    expect(advancedToggle).toHaveAttribute('aria-expanded', 'true');
+
+    // Verify the panel exists and has the correct ID
+    const panel = document.getElementById('advanced-settings-panel');
+    expect(panel).toBeInTheDocument();
+
+    // Verify content is inside the panel (e.g. Error Correction Level)
+    expect(screen.getByText('Error Correction Level')).toBeInTheDocument();
+    expect(panel).toContainElement(screen.getByText('Error Correction Level').closest('div')?.parentElement);
+  });
+});


### PR DESCRIPTION
Adds `aria-expanded` and `aria-controls` to the "Advanced Mode" toggle button in `StyleControls` and ensures the content panel has the corresponding `id`. This adheres to the WAI-ARIA disclosure pattern for collapsible sections.

- Adds `aria-expanded` state to button
- Adds `aria-controls` pointing to panel ID
- Adds `id="advanced-settings-panel"` to content div
- Adds regression test `src/components/StyleControls_Accessibility.test.tsx`