### PR TITLE
Add dynamic Social Meta Tags (Open Graph, Twitter) to Head.tsx

### DIFF
--- a/src/layouts/Head.test.tsx
+++ b/src/layouts/Head.test.tsx
@@ -1,0 +1,52 @@
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import HeadDefault from './Head';
+import { vi } from 'vitest';
+
+// Mock usePageContext
+const mockPageContext = {
+  urlPathname: '/',
+  config: {
+    title: 'Test Title',
+    description: 'Test Description'
+  }
+};
+
+vi.mock('vike-react/usePageContext', () => ({
+  usePageContext: () => mockPageContext
+}));
+
+describe('HeadDefault', () => {
+  it('renders social meta tags correctly', () => {
+    const { container } = render(<HeadDefault />);
+
+    // Debug output
+    // console.log("Container HTML:", container.innerHTML);
+    // console.log("Head HTML:", document.head.innerHTML);
+    // console.log("Body HTML:", document.body.innerHTML);
+
+    // Check if they ended up in head (unlikely with just render) or body
+    // Note: React Testing Library renders into a div in document.body.
+
+    // Let's search in the whole document
+    const getMeta = (attr: string, value: string) =>
+      document.querySelector(`meta[${attr}="${value}"]`) || container.querySelector(`meta[${attr}="${value}"]`);
+
+    // Check Open Graph
+    const ogTitle = getMeta('property', 'og:title');
+    // console.log("og:title found?", ogTitle?.outerHTML);
+
+    expect(ogTitle).not.toBeNull();
+    expect(ogTitle).toHaveAttribute('content', 'Test Title');
+
+    const ogDesc = getMeta('property', 'og:description');
+    expect(ogDesc).not.toBeNull();
+    expect(ogDesc).toHaveAttribute('content', 'Test Description');
+
+    // Check Twitter
+    const twTitle = getMeta('name', 'twitter:title');
+    expect(twTitle).not.toBeNull();
+    expect(twTitle).toHaveAttribute('content', 'Test Title');
+  });
+});

--- a/src/layouts/Head.tsx
+++ b/src/layouts/Head.tsx
@@ -23,12 +23,19 @@ export default function HeadDefault() {
   const DOMAIN = "https://qrcraftly.com";
   const canonicalUrl = `${DOMAIN}${path}`;
 
+  // Access config from pageContext if available (vike-react puts it there)
+  // or fall back to defaults
+  // @ts-ignore - pageContext.config is injected by vike-react but types might not be fully updated
+  const config = pageContext.config || {};
+  const title = config.title || "QRCraftly - Free Custom QR Code Generator";
+  const description = config.description || "Free, secure, and client-side QR code generator with zero-knowledge architecture.";
+
   const schemaData = {
     "@context": "https://schema.org",
     "@type": "WebSite",
     "name": "QRCraftly",
     "url": DOMAIN,
-    "description": "Free, secure, and client-side QR code generator with zero-knowledge architecture.",
+    "description": description,
     "publisher": {
       "@type": "Organization",
       "name": "QRCraftly",
@@ -77,7 +84,7 @@ export default function HeadDefault() {
         Note: 'viewport' and 'description' are handled by Vike/Config to avoid duplicates.
         Build output confirmed Vike injects: <meta name="viewport" content="width=device-width,initial-scale=1">
 
-        The 'title' is also injected by Vike based on +config.ts
+        The 'title' is also injected by Vike based on +config.ts, but Open Graph tags are NOT.
       */}
 
       {/* Global Structured Data */}
@@ -91,14 +98,19 @@ export default function HeadDefault() {
       <meta property="og:site_name" content="QRCraftly" />
       <meta property="og:type" content="website" />
       <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
       {/*
         TODO: Replace with a dedicated social share image (1200x630px) when available.
         Current fallback is favicon.png to ensure *some* image appears.
       */}
       <meta property="og:image" content={`${DOMAIN}/favicon.png`} />
+      <meta property="og:image:alt" content="QRCraftly Logo" />
 
       {/* Social Signals (Twitter) */}
       <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
       <meta name="twitter:image" content={`${DOMAIN}/favicon.png`} />
 
       <link rel="icon" type="image/png" href="/favicon.png" />


### PR DESCRIPTION
- Injects `og:title`, `og:description`, `og:image:alt`, `twitter:title`, and `twitter:description` meta tags.
- Uses `pageContext.config` values (title/description) with robust fallbacks.
- Adds `src/layouts/Head.test.tsx` to verify correct rendering of meta tags.
- Improves SEO visibility and social sharing previews.