### PR TITLE
docs: add quality assurance section to README

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,7 @@
+## 2025-12-18 - Hidden CI Requirements
+**Insight:** The CI pipeline enforces Type Checking (`npx tsc --noEmit`) and a strict 3MB Bundle Size limit, but these are not documented in `package.json` scripts or `README.md`.
+**Guideline:** Always check `.github/workflows` to identify "ghost" build requirements that new contributors might miss.
+
+## 2025-12-18 - Python Accessibility Checks
+**Insight:** The project relies on `scripts/contrast_check.py` for WCAG compliance, which is a manual step not integrated into the standard `npm test` flow.
+**Guideline:** Ensure manual compliance scripts are clearly documented in the "Quality Assurance" section of the README.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ QRCraftly is a powerful, privacy-focused, and user-friendly React application fo
 - **Accessibility**:
     - WCAG contrast checks for generated codes.
     - Fully accessible UI with keyboard navigation and screen reader support.
+- **Compliance**:
+    - Privacy-first architecture aligned with [HIPAA Technical Safeguards](COMPLIANCE.md).
 - **Dark Mode**: Fully supported dark mode interface.
 - **Responsive Design**: Works seamlessly on desktop and mobile devices.
 
@@ -83,6 +85,28 @@ npm test
 To run coverage reports:
 ```bash
 npm test -- run --coverage
+```
+
+### Quality Assurance
+
+This project enforces strict quality checks in CI. Run these locally to prevent build failures:
+
+**Type Checking:**
+```bash
+npx tsc --noEmit
+```
+
+**Accessibility & Contrast Check:**
+```bash
+python3 scripts/contrast_check.py
+```
+
+**Bundle Size Check:**
+The build pipeline enforces a 3MB limit on the client bundle.
+```bash
+npm run build
+# Check size of dist/client directory
+du -sh dist/client
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
- Add explicit commands for Type Checking (`npx tsc --noEmit`) and Accessibility Checks (`python3 scripts/contrast_check.py`).
- Document strict 3MB Bundle Size limit.
- Add link to COMPLIANCE.md in "Privacy First" section.
- Create .jules/scribe.md to track documentation learnings.

This improves the onboarding experience by preventing "ghost" CI failures for new contributors.