### PR TITLE
feat(seo): Add dynamic Open Graph and Twitter card meta tags

### DIFF
--- a/src/layouts/Head.tsx
+++ b/src/layouts/Head.tsx
@@ -16,6 +16,10 @@ export default function HeadDefault() {
   const fontUrl = "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap";
 
   const pageContext = usePageContext();
+  const { config } = pageContext;
+  const title = config?.title || "QRCraftly - Free Custom QR Code Generator";
+  const description = config?.description || "Generate beautiful, custom QR codes for free. No sign-up required. Secure, client-side generation.";
+
   // Ensure we don't end up with double slashes if urlPathname is just '/'
   const path = pageContext.urlPathname === '/' ? '' : pageContext.urlPathname;
 
@@ -91,6 +95,8 @@ export default function HeadDefault() {
       <meta property="og:site_name" content="QRCraftly" />
       <meta property="og:type" content="website" />
       <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:title" content={title as string} />
+      <meta property="og:description" content={description as string} />
       {/*
         TODO: Replace with a dedicated social share image (1200x630px) when available.
         Current fallback is favicon.png to ensure *some* image appears.
@@ -99,6 +105,8 @@ export default function HeadDefault() {
 
       {/* Social Signals (Twitter) */}
       <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={title as string} />
+      <meta name="twitter:description" content={description as string} />
       <meta name="twitter:image" content={`${DOMAIN}/favicon.png`} />
 
       <link rel="icon" type="image/png" href="/favicon.png" />


### PR DESCRIPTION
Injects `og:title`, `og:description`, `twitter:title`, and `twitter:description` tags into the head using the page context configuration. This ensures social shares display the correct page-specific title and description instead of falling back to defaults or being missing.

Verified by inspecting the build output for `dist/client/index.html` and `dist/client/wifi-qr-code/index.html`.