### PR TITLE
🛡️ Shield: Add unit tests for custom hooks

### DIFF
--- a/src/utils/hooks.test.ts
+++ b/src/utils/hooks.test.ts
@@ -1,0 +1,128 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { useDebounce, useQRInputState } from './hooks';
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('initial', 500));
+    expect(result.current).toBe('initial');
+  });
+
+  it('should debounce value updates', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'initial', delay: 500 } }
+    );
+
+    // Update value
+    rerender({ value: 'updated', delay: 500 });
+
+    // Should still be initial
+    expect(result.current).toBe('initial');
+
+    // Advance time by 200ms (less than delay)
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current).toBe('initial');
+
+    // Advance time by 300ms (total 500ms)
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe('updated');
+  });
+
+  it('should reset timer if value changes before delay', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'initial', delay: 500 } }
+    );
+
+    // First update
+    rerender({ value: 'update1', delay: 500 });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe('initial');
+
+    // Second update before timeout
+    rerender({ value: 'update2', delay: 500 });
+
+    act(() => {
+      vi.advanceTimersByTime(300); // Total 600ms from start, but only 300ms from second update
+    });
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      vi.advanceTimersByTime(200); // Total 500ms from second update
+    });
+    expect(result.current).toBe('update2');
+  });
+});
+
+describe('useQRInputState', () => {
+  type TestData = { field: string };
+  const mockConstructor = (data: TestData) => `constructed:${data.field}`;
+
+  it('should initialize with provided state', () => {
+    const mockOnChange = vi.fn();
+    const { result } = renderHook(() =>
+      useQRInputState({ field: 'init' }, mockConstructor, mockOnChange)
+    );
+
+    const [data] = result.current;
+    expect(data).toEqual({ field: 'init' });
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it('should update state and call onChange with constructed string', () => {
+    const mockOnChange = vi.fn();
+    const { result } = renderHook(() =>
+      useQRInputState({ field: 'init' }, mockConstructor, mockOnChange)
+    );
+
+    const [, update] = result.current;
+
+    act(() => {
+      update({ field: 'new' });
+    });
+
+    const [data] = result.current;
+    expect(data).toEqual({ field: 'new' });
+    expect(mockOnChange).toHaveBeenCalledWith({ value: 'constructed:new' });
+  });
+
+  it('should merge partial updates', () => {
+    type ComplexData = { a: string; b: number };
+    const complexConstructor = (d: ComplexData) => `${d.a}:${d.b}`;
+    const mockOnChange = vi.fn();
+
+    const { result } = renderHook(() =>
+      useQRInputState<ComplexData>(
+        { a: 'start', b: 1 },
+        complexConstructor,
+        mockOnChange
+      )
+    );
+
+    const [, update] = result.current;
+
+    act(() => {
+      update({ b: 2 });
+    });
+
+    const [data] = result.current;
+    expect(data).toEqual({ a: 'start', b: 2 });
+    expect(mockOnChange).toHaveBeenCalledWith({ value: 'start:2' });
+  });
+});


### PR DESCRIPTION
Added `src/utils/hooks.test.ts` to provide robust unit testing for `useDebounce` and `useQRInputState`. This eliminates potential regression risks in the core debouncing and input state management logic.

- Implemented deterministic tests for `useDebounce` using `vi.useFakeTimers()`.
- Added standard React hook tests for `useQRInputState` to verify state updates and callback execution.
- Ensured tests run cleanly with proper timer setup and teardown (`beforeEach`, `afterEach`).