### PR TITLE
Refactor: Extract WifiEncryption enum to replace magic strings

### DIFF
--- a/.jules/polish.md
+++ b/.jules/polish.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - [Magic Strings in Data Types]
+**Smell:** Primitive Obsession - hardcoded string literals (e.g., 'WPA', 'nopass') used repeatedly across types, components, and helpers.
+**Remedy:** Extract to shared Enums (e.g., `WifiEncryption`) to enforce consistency and enable safe refactoring.

--- a/src/components/InputPanel.test.tsx
+++ b/src/components/InputPanel.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import InputPanel from './InputPanel';
 import { DEFAULT_CONFIG } from '../constants';
-import { QRType, QRConfig } from '../types';
+import { QRType, QRConfig, WifiEncryption } from '../types';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 describe('InputPanel Component', () => {
@@ -68,7 +68,7 @@ describe('InputPanel Component', () => {
 
     // Change encryption to WPA2-EAP
     const encryptionSelect = screen.getByLabelText('Encryption');
-    fireEvent.change(encryptionSelect, { target: { value: 'WPA2-EAP' } });
+    fireEvent.change(encryptionSelect, { target: { value: WifiEncryption.WPA2_EAP } });
 
     act(() => {
       vi.advanceTimersByTime(100);
@@ -114,7 +114,7 @@ describe('InputPanel Component', () => {
     renderPanel({ type: QRType.WIFI });
 
     const encryptionSelect = screen.getByLabelText('Encryption');
-    fireEvent.change(encryptionSelect, { target: { value: 'nopass' } });
+    fireEvent.change(encryptionSelect, { target: { value: WifiEncryption.NOPASS } });
 
     act(() => {
       vi.advanceTimersByTime(100);
@@ -183,7 +183,7 @@ describe('InputPanel Component', () => {
 
     // 2. Change encryption to nopass
     const encryptionSelect = screen.getByLabelText('Encryption');
-    fireEvent.change(encryptionSelect, { target: { value: 'nopass' } });
+    fireEvent.change(encryptionSelect, { target: { value: WifiEncryption.NOPASS } });
 
     act(() => {
       vi.advanceTimersByTime(100);

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { QRConfig, QRType, WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData } from '../types';
+import { QRConfig, QRType, WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption } from '../types';
 import { Wifi, Link, Type, Mail, UserSquare2, Phone, MessageSquare, CreditCard, Eye, EyeOff } from 'lucide-react';
 import {
   constructWifiString,
@@ -36,7 +36,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
   const [showWifiPassword, setShowWifiPassword] = useState(false);
 
   const [wifiData, handleWifiChange] = useQRInputState<WifiData>(
-    { ssid: '', password: '', encryption: 'WPA', hidden: false, eapIdentity: '' },
+    { ssid: '', password: '', encryption: WifiEncryption.WPA, hidden: false, eapIdentity: '' },
     constructWifiString,
     onChange
   );
@@ -167,17 +167,17 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                 <select
                   id="wifi-encryption"
                   value={wifiData.encryption}
-                  onChange={(e) => handleWifiChange({ encryption: e.target.value as any })}
+                  onChange={(e) => handleWifiChange({ encryption: e.target.value as WifiEncryption })}
                   className={selectClasses}
                 >
-                  <option value="WPA">WPA / WPA2 / WPA3 (Standard)</option>
-                  <option value="WEP">WEP (Legacy)</option>
-                  <option value="WPA2-EAP">WPA2 Enterprise (EAP)</option>
-                  <option value="nopass">None (Open Network)</option>
+                  <option value={WifiEncryption.WPA}>WPA / WPA2 / WPA3 (Standard)</option>
+                  <option value={WifiEncryption.WEP}>WEP (Legacy)</option>
+                  <option value={WifiEncryption.WPA2_EAP}>WPA2 Enterprise (EAP)</option>
+                  <option value={WifiEncryption.NOPASS}>None (Open Network)</option>
                 </select>
             </div>
 
-            {wifiData.encryption === 'WPA2-EAP' && (
+            {wifiData.encryption === WifiEncryption.WPA2_EAP && (
                 <div>
                     <label htmlFor="wifi-identity" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Identity / Username</label>
                     <input
@@ -191,7 +191,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                 </div>
             )}
 
-            {wifiData.encryption !== 'nopass' && (
+            {wifiData.encryption !== WifiEncryption.NOPASS && (
                 <div>
                 <label htmlFor="wifi-password" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Password</label>
                 <div className="relative">

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,16 @@ export enum QRType {
 }
 
 /**
+ * Defines the encryption type for WiFi networks.
+ */
+export enum WifiEncryption {
+  WPA = 'WPA',
+  WEP = 'WEP',
+  NOPASS = 'nopass',
+  WPA2_EAP = 'WPA2-EAP',
+}
+
+/**
  * Defines the shape of the padding area around an embedded logo.
  */
 export type LogoPaddingStyle = 'square' | 'circle' | 'none';
@@ -91,7 +101,7 @@ export interface WifiData {
   /** The password for the WiFi network. */
   password: string;
   /** The encryption type used by the network. */
-  encryption: 'WPA' | 'WEP' | 'nopass' | 'WPA2-EAP';
+  encryption: WifiEncryption;
   /** Whether the network SSID is hidden. */
   hidden: boolean;
   /** The identity for WPA2-EAP enterprise networks (optional). */

--- a/src/utils/qrHelpers.test.ts
+++ b/src/utils/qrHelpers.test.ts
@@ -9,7 +9,7 @@ import {
   escapeWifiString,
   escapeVCardString
 } from './qrHelpers';
-import { WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData } from '../types';
+import { WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption } from '../types';
 
 describe('QR Helpers', () => {
   describe('constructWifiString', () => {
@@ -17,7 +17,7 @@ describe('QR Helpers', () => {
       const data: WifiData = {
         ssid: 'MyNetwork',
         password: 'password123',
-        encryption: 'WPA',
+        encryption: WifiEncryption.WPA,
         hidden: false
       };
       expect(constructWifiString(data)).toBe('WIFI:T:WPA;S:MyNetwork;P:password123;H:false;;');
@@ -27,7 +27,7 @@ describe('QR Helpers', () => {
       const data: WifiData = {
         ssid: 'EnterpriseNet',
         password: 'securepass',
-        encryption: 'WPA2-EAP',
+        encryption: WifiEncryption.WPA2_EAP,
         hidden: false,
         eapIdentity: 'user@domain.com'
       };
@@ -38,7 +38,7 @@ describe('QR Helpers', () => {
       const data: WifiData = {
         ssid: 'OpenNet',
         password: 'ignored',
-        encryption: 'nopass',
+        encryption: WifiEncryption.NOPASS,
         hidden: false
       };
       expect(constructWifiString(data)).toBe('WIFI:T:nopass;S:OpenNet;H:false;;');
@@ -48,7 +48,7 @@ describe('QR Helpers', () => {
       const data: WifiData = {
         ssid: 'Net;Work',
         password: 'pass:word\\',
-        encryption: 'WPA',
+        encryption: WifiEncryption.WPA,
         hidden: false
       };
       // Expect: Net\;Work and pass\:word\\
@@ -59,7 +59,7 @@ describe('QR Helpers', () => {
       const data: WifiData = {
         ssid: 'HiddenNet',
         password: 'pass',
-        encryption: 'WPA',
+        encryption: WifiEncryption.WPA,
         hidden: true
       };
       expect(constructWifiString(data)).toContain('H:true');

--- a/src/utils/qrHelpers.ts
+++ b/src/utils/qrHelpers.ts
@@ -1,4 +1,4 @@
-import { WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData } from '../types';
+import { WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption } from '../types';
 
 /**
  * Checks if a URL string contains a dangerous protocol.
@@ -36,13 +36,13 @@ export const constructWifiString = (data: WifiData): string => {
   const ssid = escapeWifiString(data.ssid);
   const hidden = data.hidden;
 
-  if (data.encryption === 'WPA2-EAP') {
+  if (data.encryption === WifiEncryption.WPA2_EAP) {
     const identity = escapeWifiString(data.eapIdentity);
     const password = escapeWifiString(data.password);
-    return `WIFI:T:WPA2-EAP;S:${ssid};I:${identity};P:${password};H:${hidden};;`;
+    return `WIFI:T:${WifiEncryption.WPA2_EAP};S:${ssid};I:${identity};P:${password};H:${hidden};;`;
   }
 
-  if (data.encryption === 'nopass') {
+  if (data.encryption === WifiEncryption.NOPASS) {
     return `WIFI:T:${data.encryption};S:${ssid};H:${hidden};;`;
   }
 


### PR DESCRIPTION
Replaces repeated string literals ('WPA', 'nopass', etc.) with a strict `WifiEncryption` enum in `src/types.ts`. Updates `WifiData` interface, `InputPanel.tsx`, `qrHelpers.ts`, and relevant tests to use the new Enum.

This change improves type safety, reduces duplication (DRY), and eliminates "Magic Strings" related to WiFi encryption types.

Verified with full test suite (`pnpm test`). No functional changes.