### PR TITLE
feat(ux): add character count to text inputs

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -11,3 +11,7 @@
 ## 2025-02-18 - [Silent Failure in Color Contrast Calc]
 **Discovery:** `getContrastRatio` silently treats invalid hex strings (e.g. `#GGGGGG`) as Black (`#000000`) due to `parseInt` returning `NaN` and bitwise operators converting `NaN` to `0`. This results in a false positive contrast ratio of 21 against white, masking potential data issues.
 **Defense:** Implement strict regex validation for hex strings in `getContrastRatio` to ensure invalid inputs return 0 (failure), matching the behavior for invalid lengths.
+
+## 2025-02-18 - Playwright Label Ambiguity
+**Discovery:** Using `page.get_by_label("Content")` in Playwright failed because it matched both the textarea (correct) and the QR Code canvas (incorrect) which had a descriptive `aria-label` containing "Content".
+**Defense:** Use specific locators like `page.locator("#id")` or strict role matching `page.get_by_role("textbox", name="Content", exact=True)` to avoid ambiguity with non-interactive elements that have rich accessibility labels.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2393,7 +2393,6 @@
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/src/components/CharCount.test.tsx
+++ b/src/components/CharCount.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { CharCount } from './CharCount';
+
+describe('CharCount', () => {
+  it('renders the correct count and max', () => {
+    render(<CharCount current={10} max={100} />);
+    expect(screen.getByText('10 / 100')).toBeInTheDocument();
+  });
+
+  it('uses neutral color when usage is low', () => {
+    const { container } = render(<CharCount current={50} max={100} />);
+    // 50 is 50%, so not near limit
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('text-slate-400');
+    expect(div.className).not.toContain('text-amber-600');
+    expect(div.className).not.toContain('text-rose-600');
+  });
+
+  it('uses warning color when usage is near limit (90%)', () => {
+    const { container } = render(<CharCount current={90} max={100} />);
+    // 90 is 90%, so near limit
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('text-amber-600');
+    expect(div.className).not.toContain('text-rose-600');
+  });
+
+  it('uses danger color when usage is at or above limit', () => {
+    const { container } = render(<CharCount current={100} max={100} />);
+    // 100 is 100%
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('text-rose-600');
+  });
+
+  it('uses danger color when usage is exceeded', () => {
+    const { container } = render(<CharCount current={101} max={100} />);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('text-rose-600');
+  });
+});

--- a/src/components/CharCount.tsx
+++ b/src/components/CharCount.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface CharCountProps {
+  current: number;
+  max: number;
+}
+
+export const CharCount: React.FC<CharCountProps> = ({ current, max }) => {
+  const isNearLimit = current >= max * 0.9;
+  const isAtLimit = current >= max;
+
+  let colorClass = "text-slate-400 dark:text-slate-500";
+  if (isAtLimit) {
+    colorClass = "text-rose-600 dark:text-rose-400 font-medium";
+  } else if (isNearLimit) {
+    colorClass = "text-amber-600 dark:text-amber-400";
+  }
+
+  return (
+    <div className={`text-xs text-right mt-1 transition-colors ${colorClass}`} aria-live="polite">
+      {current} / {max}
+    </div>
+  );
+};

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -11,6 +11,7 @@ import {
   isDangerousUrl
 } from '../utils/qrHelpers';
 import { useQRInputState } from '../utils/hooks';
+import { CharCount } from './CharCount';
 
 /**
  * Props for the InputPanel component.
@@ -144,6 +145,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
               value={config.value}
               onChange={(e) => onChange({ value: e.target.value })}
             />
+            <CharCount current={config.value.length} max={2500} />
           </div>
         )}
 
@@ -268,6 +270,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                         onChange={(e) => handleEmailChange({ body: e.target.value })}
                         className={textAreaClasses}
                     />
+                    <CharCount current={emailData.body.length} max={2000} />
                 </div>
             </div>
         )}
@@ -433,6 +436,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                         onChange={(e) => handleSmsChange({ message: e.target.value })}
                         className={textAreaClasses}
                     />
+                    <CharCount current={smsData.message.length} max={1600} />
                 </div>
             </div>
         )}


### PR DESCRIPTION
This pull request introduces a new `CharCount` component to visually display character usage and limits in text input fields, improving user feedback as they approach or exceed character limits. The component is fully tested and integrated into relevant input areas of the application. Additionally, a documentation update addresses a Playwright test ambiguity related to accessibility labels.

Component addition and integration:

* Added a new `CharCount` component (`src/components/CharCount.tsx`) that displays the current character count and limit, with dynamic color changes to indicate low, warning, or danger states as users approach or exceed the limit.
* Integrated the `CharCount` component into the main input, email body, and SMS message fields in `InputPanel`, with appropriate character limits for each (`2500`, `2000`, and `1600` respectively). [[1]](diffhunk://#diff-05c32db593d05444d92c54a25be53bffce84336a329031f97b8735bda2bebcb3R148) [[2]](diffhunk://#diff-05c32db593d05444d92c54a25be53bffce84336a329031f97b8735bda2bebcb3R273) [[3]](diffhunk://#diff-05c32db593d05444d92c54a25be53bffce84336a329031f97b8735bda2bebcb3R439) [[4]](diffhunk://#diff-05c32db593d05444d92c54a25be53bffce84336a329031f97b8735bda2bebcb3R14)
* Added comprehensive unit tests for `CharCount` to ensure correct rendering and color logic based on usage levels.

Documentation improvements:

* Updated `.jules/shield.md` to document a Playwright testing issue with ambiguous label matching, and recommended best practices for selecting elements in tests to avoid similar problems.