### PR TITLE
⚡ Bolt: Batch render canvas calls for complex QR styles

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-01-26 - Canvas Path Batching
+**Learning:** The Canvas 2D API's `fill()` and `stroke()` methods are expensive operations. When rendering many independent shapes (like QR code modules), calling `ctx.fill()` for each shape creates a significant performance bottleneck.
+**Action:** For repetitive shapes, construct a single path containing multiple subpaths (using `ctx.moveTo`) and call `ctx.fill()` once at the end. Refactor drawing helpers to separate path construction from rendering to enable this batching strategy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,6 +152,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -680,6 +681,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -723,6 +725,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2480,8 +2483,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2578,6 +2580,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2970,6 +2973,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3061,6 +3065,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-addon-api": "^7.0.0",
         "prebuild-install": "^7.1.3"
@@ -3315,8 +3320,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.266",
@@ -3800,6 +3804,7 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -4163,7 +4168,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4548,6 +4552,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4597,7 +4602,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4613,7 +4617,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4680,6 +4683,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4689,6 +4693,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4701,8 +4706,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4719,6 +4723,7 @@
       "resolved": "https://registry.npmjs.org/react-streaming/-/react-streaming-0.4.13.tgz",
       "integrity": "sha512-LNwxjglFKYDHxkt2N0rLPzqJiR/mWec94VVdi683t/Ha2VXxB8BXxni+TKdWt12v6fM1ygNgJYtzQrxFaTBFgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@brillout/import": "^0.2.3",
         "@brillout/json-serializer": "^0.5.1",
@@ -5363,6 +5368,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -5479,6 +5485,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5554,6 +5561,7 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -5731,6 +5739,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/src/components/QRCanvas.tsx
+++ b/src/components/QRCanvas.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { QRConfig, QRStyle } from '../types';
-import { drawRoundRect, drawPoly, drawStar, drawRoughRect, drawScribble } from '../utils/canvasHelpers';
+import { drawRoundRect, drawPoly, drawStar, drawRoughRect, drawScribble, drawPolyPath, drawStarPath } from '../utils/canvasHelpers';
 
 /**
  * Props for the QRCanvas component.
@@ -385,7 +385,7 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
         ctx.fillStyle = config.fgColor;
 
         // Optimization: Batch drawing for compatible styles to reduce draw calls
-        const isBatchable = [QRStyle.STANDARD, QRStyle.MODERN, QRStyle.SWISS, QRStyle.FLUID].includes(config.style);
+        const isBatchable = [QRStyle.STANDARD, QRStyle.MODERN, QRStyle.SWISS, QRStyle.FLUID, QRStyle.HIVE, QRStyle.STARBURST].includes(config.style);
 
         if (isBatchable) {
             ctx.beginPath();
@@ -416,6 +416,12 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
                            ctx.moveTo(cx + (cellSize/2 * 1.1), cy);
                            ctx.arc(cx, cy, cellSize/2 * 1.1, 0, Math.PI*2);
                            break;
+                       case QRStyle.HIVE:
+                           drawPolyPath(ctx, cx, cy, cellSize/1.55, 6, 0);
+                           break;
+                       case QRStyle.STARBURST:
+                           drawStarPath(ctx, cx, cy, cellSize/1.5, cellSize/2.2, 5);
+                           break;
                        case QRStyle.STANDARD:
                        default:
                            ctx.rect(Math.floor(x), Math.floor(y), Math.ceil(cellSize), Math.ceil(cellSize));
@@ -442,17 +448,9 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
                         if (hasLeft) ctx.fillRect(x, cy - thickness/2, cellSize/2 + 1, thickness);
                         if (hasTop) ctx.fillRect(cx - thickness/2, y, thickness, cellSize/2 + 1);
                         break;
-                      case QRStyle.HIVE:
-                        // Massive Hexagon
-                        drawPoly(ctx, cx, cy, cellSize/1.55, 6, 0, true);
-                        break;
                       case QRStyle.GRUNGE:
                         // Full size rough rect, minimal jitter
                         drawRoughRect(ctx, x, y, cellSize, cellSize);
-                        break;
-                      case QRStyle.STARBURST:
-                         // Fat star - nearly a square
-                        drawStar(ctx, cx, cy, cellSize/1.5, cellSize/2.2, 5, true);
                         break;
                   }
               }

--- a/src/components/QRCanvasBatching.test.tsx
+++ b/src/components/QRCanvasBatching.test.tsx
@@ -1,0 +1,125 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach, Mock } from 'vitest';
+import QRCanvas from './QRCanvas';
+import { DEFAULT_CONFIG } from '../constants';
+import { QRStyle } from '../types';
+import QRCode from 'qrcode';
+
+// Mock qrcode module
+vi.mock('qrcode', () => {
+  const createMock = vi.fn();
+  return {
+    create: createMock,
+    default: {
+      create: createMock,
+    },
+  };
+});
+
+// Mock Image
+const originalImage = window.Image;
+
+describe('QRCanvas Batch Rendering Optimization', () => {
+  let mockContext: any;
+  let mockModules: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup Mock Canvas Context
+    mockContext = {
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      roundRect: vi.fn(),
+      beginPath: vi.fn(),
+      fill: vi.fn(),
+      stroke: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      scale: vi.fn(),
+      drawImage: vi.fn(),
+      arc: vi.fn(),
+      rect: vi.fn(),
+      canvas: { width: 0, height: 0 },
+      fillStyle: '',
+      strokeStyle: '',
+    };
+
+    // Mock getContext
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation((contextId) => {
+      if (contextId === '2d') {
+        return mockContext;
+      }
+      return null;
+    });
+
+    // Setup Mock QRCode Data
+    const size = 21;
+    mockModules = {
+      size: size,
+      get: vi.fn().mockReturnValue(false),
+    };
+
+    (QRCode.create as unknown as Mock).mockReturnValue({
+      modules: mockModules,
+    });
+
+    // Mock Image
+    window.Image = class {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      src = '';
+      complete = false;
+      crossOrigin = '';
+    } as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.Image = originalImage;
+  });
+
+  const setModule = (r: number, c: number, val: boolean) => {
+      mockModules.get.mockImplementation((row: number, col: number) => {
+          if (row === r && col === c) return val;
+          return false;
+      });
+  };
+
+  it('batches fill calls for HIVE style', async () => {
+      // Set up 5 modules scattered around
+      mockModules.get.mockImplementation((r: number, c: number) => {
+          // Avoid eyes (0-7, 0-7), (0-7, 14-21), (14-21, 0-7)
+          if (r === 10 && c >= 10 && c < 15) return true;
+          return false;
+      });
+
+      const config = { ...DEFAULT_CONFIG, style: QRStyle.HIVE };
+      render(<QRCanvas config={config} />);
+
+      await waitFor(() => {
+          // 3 eyes (1 fill each for HIVE style eye pupil) + 1 batch fill for modules = 4 fills
+          // Previously, this would be 3 + 5 = 8 fills.
+          expect(mockContext.fill).toHaveBeenCalledTimes(4);
+      });
+  });
+
+  it('batches fill calls for STARBURST style', async () => {
+      // Set up 5 modules scattered around
+      mockModules.get.mockImplementation((r: number, c: number) => {
+          if (r === 10 && c >= 10 && c < 15) return true;
+          return false;
+      });
+
+      const config = { ...DEFAULT_CONFIG, style: QRStyle.STARBURST };
+      render(<QRCanvas config={config} />);
+
+      await waitFor(() => {
+          // 3 eyes (1 fill each for STARBURST eye pupil) + 1 batch fill for modules = 4 fills
+          expect(mockContext.fill).toHaveBeenCalledTimes(4);
+      });
+  });
+});

--- a/src/utils/canvasHelpers.ts
+++ b/src/utils/canvasHelpers.ts
@@ -28,6 +28,26 @@ export const drawRoundRect = (ctx: CanvasRenderingContext2D, x: number, y: numbe
 };
 
 /**
+ * Generates a regular polygon path.
+ * @param ctx The canvas context.
+ * @param x The center x coordinate.
+ * @param y The center y coordinate.
+ * @param r The radius.
+ * @param sides The number of sides.
+ * @param rotate Rotation angle in radians (default: 0).
+ */
+export const drawPolyPath = (ctx: CanvasRenderingContext2D, x: number, y: number, r: number, sides: number, rotate: number = 0) => {
+  for (let i = 0; i < sides; i++) {
+    const theta = rotate + (i * 2 * Math.PI / sides);
+    const px = x + r * Math.cos(theta);
+    const py = y + r * Math.sin(theta);
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+  }
+  ctx.closePath();
+};
+
+/**
  * Draws a regular polygon.
  * @param ctx The canvas context.
  * @param x The center x coordinate.
@@ -39,34 +59,25 @@ export const drawRoundRect = (ctx: CanvasRenderingContext2D, x: number, y: numbe
  */
 export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r: number, sides: number, rotate: number = 0, fill: boolean = true) => {
   ctx.beginPath();
-  for (let i = 0; i < sides; i++) {
-    const theta = rotate + (i * 2 * Math.PI / sides);
-    const px = x + r * Math.cos(theta);
-    const py = y + r * Math.sin(theta);
-    if (i === 0) ctx.moveTo(px, py);
-    else ctx.lineTo(px, py);
-  }
-  ctx.closePath();
+  drawPolyPath(ctx, x, y, r, sides, rotate);
   if (fill) ctx.fill(); else ctx.stroke();
 };
 
 /**
- * Draws a star shape.
+ * Generates a star path.
  * @param ctx The canvas context.
  * @param cx The center x coordinate.
  * @param cy The center y coordinate.
  * @param outerR The outer radius.
  * @param innerR The inner radius.
  * @param spikes The number of spikes.
- * @param fill Whether to fill the star (default: true).
  */
-export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, outerR: number, innerR: number, spikes: number, fill: boolean = true) => {
+export const drawStarPath = (ctx: CanvasRenderingContext2D, cx: number, cy: number, outerR: number, innerR: number, spikes: number) => {
   let rot = Math.PI / 2 * 3;
   let x = cx;
   let y = cy;
   const step = Math.PI / spikes;
 
-  ctx.beginPath();
   ctx.moveTo(cx, cy - outerR);
   for (let i = 0; i < spikes; i++) {
     x = cx + Math.cos(rot) * outerR;
@@ -81,6 +92,21 @@ export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, 
   }
   ctx.lineTo(cx, cy - outerR);
   ctx.closePath();
+};
+
+/**
+ * Draws a star shape.
+ * @param ctx The canvas context.
+ * @param cx The center x coordinate.
+ * @param cy The center y coordinate.
+ * @param outerR The outer radius.
+ * @param innerR The inner radius.
+ * @param spikes The number of spikes.
+ * @param fill Whether to fill the star (default: true).
+ */
+export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, outerR: number, innerR: number, spikes: number, fill: boolean = true) => {
+  ctx.beginPath();
+  drawStarPath(ctx, cx, cy, outerR, innerR, spikes);
   if (fill) ctx.fill(); else ctx.stroke();
 };
 


### PR DESCRIPTION
⚡ Bolt: Optimized canvas rendering for Hive and Starburst styles.

💡 **What:**
Implemented batch rendering for `QRStyle.HIVE` and `QRStyle.STARBURST` styles. Refactored `canvasHelpers.ts` to expose path-only functions (`drawPolyPath`, `drawStarPath`) that add subpaths to the canvas context without triggering a draw call. Updated `QRCanvas.tsx` to utilize these helpers within the existing batch rendering loop.

🎯 **Why:**
Previously, these styles called `ctx.beginPath()` and `ctx.fill()` for *every single module* (hundreds of times per QR code). This is an expensive operation in the Canvas 2D API.

📊 **Impact:**
- Reduces `ctx.fill()` calls for these styles from `N` (number of modules) to ~4 (1 for the batch + 3 for eyes).
- Significantly reduces overhead on the main thread during rendering.

🔬 **Measurement:**
Verified with a new test `src/components/QRCanvasBatching.test.tsx` which mocks the canvas context and asserts that `ctx.fill` is called 4 times instead of hundreds when rendering these styles. Visual verification confirmed no regressions in output.

---
*PR created automatically by Jules for task [17001612375478306084](https://jules.google.com/task/17001612375478306084) started by @fderuiter*