### PR TITLE
🛡️ Shield: Refactor flaky QRCanvasExtended tests to use waitFor

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -11,3 +11,7 @@
 ## 2025-02-18 - [Silent Failure in Color Contrast Calc]
 **Discovery:** `getContrastRatio` silently treats invalid hex strings (e.g. `#GGGGGG`) as Black (`#000000`) due to `parseInt` returning `NaN` and bitwise operators converting `NaN` to `0`. This results in a false positive contrast ratio of 21 against white, masking potential data issues.
 **Defense:** Implement strict regex validation for hex strings in `getContrastRatio` to ensure invalid inputs return 0 (failure), matching the behavior for invalid lengths.
+
+## 2025-02-18 - Flaky Canvas Tests with setTimeout
+**Discovery:** `QRCanvasExtended.test.tsx` used hardcoded `setTimeout` delays (100ms, 200ms) to wait for async canvas rendering. This causes flakiness if the environment is slow, or wastes time if it's fast. It also triggered `act(...)` warnings because state updates happened outside React's test loop.
+**Defense:** Replaced `setTimeout` with `waitFor` from `@testing-library/react`. This makes the test deterministic, faster, and implicitly handles async state updates correctly.

--- a/src/components/QRCanvasExtended.test.tsx
+++ b/src/components/QRCanvasExtended.test.tsx
@@ -1,51 +1,79 @@
-
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
 import QRCanvas from './QRCanvas';
 import { DEFAULT_CONFIG } from '../constants';
 import { QRConfig } from '../types';
 
-describe('QRCanvas Border Extended Features', () => {
-  const mockContext = {
-    fillRect: vi.fn(),
-    clearRect: vi.fn(),
-    scale: vi.fn(),
-    drawImage: vi.fn(),
-    beginPath: vi.fn(),
-    fill: vi.fn(),
-    arc: vi.fn(),
-    roundRect: vi.fn(),
-    rect: vi.fn(),
-    save: vi.fn(),
-    restore: vi.fn(),
-    translate: vi.fn(),
-    rotate: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    closePath: vi.fn(),
-    bezierCurveTo: vi.fn(),
-    strokeRect: vi.fn(),
-    setLineDash: vi.fn(),
-    fillText: vi.fn(),
-    measureText: vi.fn().mockReturnValue({ width: 10 }),
-    font: '',
-    textAlign: '',
-    textBaseline: '',
-  };
+// Save original Image constructor
+const originalImage = window.Image;
 
-  const setupCanvasMock = (originalCreateElement: any) => {
-    const canvas = originalCreateElement.call(document, 'canvas');
-    canvas.getContext = vi.fn().mockReturnValue(mockContext);
-    return canvas;
-  };
+describe('QRCanvas Border Extended Features', () => {
+  let mockContext: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockContext = {
+      fillRect: vi.fn(),
+      clearRect: vi.fn(),
+      scale: vi.fn(),
+      drawImage: vi.fn(),
+      beginPath: vi.fn(),
+      fill: vi.fn(),
+      arc: vi.fn(),
+      roundRect: vi.fn(),
+      rect: vi.fn(),
+      save: vi.fn(),
+      restore: vi.fn(),
+      translate: vi.fn(),
+      rotate: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      bezierCurveTo: vi.fn(),
+      strokeRect: vi.fn(),
+      setLineDash: vi.fn(),
+      fillText: vi.fn(),
+      measureText: vi.fn().mockReturnValue({ width: 10 }),
+      font: '',
+      textAlign: '',
+      textBaseline: '',
+    };
+
+    // Spy on getContext to return our mock context
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation((contextId) => {
+      if (contextId === '2d') {
+        return mockContext;
+      }
+      return null;
+    });
+
+    // Mock Image to simulate loading
+    class MockImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      src = '';
+      complete = false;
+      crossOrigin = '';
+      constructor() {
+        // Simulate async loading with a small delay
+        setTimeout(() => {
+          if (this.onload) {
+            this.complete = true;
+            this.onload();
+          }
+        }, 10);
+      }
+    }
+    window.Image = MockImage as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.Image = originalImage;
+  });
 
   it('renders dashed border style', async () => {
-    const originalCreateElement = document.createElement;
-    document.createElement = vi.fn((tagName) => {
-        if (tagName === 'canvas') return setupCanvasMock(originalCreateElement);
-        return originalCreateElement.call(document, tagName);
-    }) as any;
-
     const config: QRConfig = {
       ...DEFAULT_CONFIG,
       isBorderEnabled: true,
@@ -55,21 +83,14 @@ describe('QRCanvas Border Extended Features', () => {
     };
 
     render(<QRCanvas config={config} size={100} />);
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(mockContext.setLineDash).toHaveBeenCalled();
-    expect(mockContext.strokeRect).toHaveBeenCalled();
-
-    document.createElement = originalCreateElement;
+    await waitFor(() => {
+      expect(mockContext.setLineDash).toHaveBeenCalled();
+      expect(mockContext.strokeRect).toHaveBeenCalled();
+    });
   });
 
   it('renders border text', async () => {
-    const originalCreateElement = document.createElement;
-    document.createElement = vi.fn((tagName) => {
-        if (tagName === 'canvas') return setupCanvasMock(originalCreateElement);
-        return originalCreateElement.call(document, tagName);
-    }) as any;
-
     const config: QRConfig = {
       ...DEFAULT_CONFIG,
       isBorderEnabled: true,
@@ -79,32 +100,13 @@ describe('QRCanvas Border Extended Features', () => {
     };
 
     render(<QRCanvas config={config} size={100} />);
-    await new Promise((resolve) => setTimeout(resolve, 100));
 
-    expect(mockContext.fillText).toHaveBeenCalledWith('Scan Me', expect.any(Number), expect.any(Number));
-
-    document.createElement = originalCreateElement;
+    await waitFor(() => {
+      expect(mockContext.fillText).toHaveBeenCalledWith('Scan Me', expect.any(Number), expect.any(Number));
+    });
   });
 
   it('renders border logo', async () => {
-    const originalCreateElement = document.createElement;
-    document.createElement = vi.fn((tagName) => {
-        if (tagName === 'canvas') return setupCanvasMock(originalCreateElement);
-        return originalCreateElement.call(document, tagName);
-    }) as any;
-
-    // Mock Image
-    const originalImage = window.Image;
-    window.Image = class {
-      onload: any;
-      src: string = '';
-      crossOrigin: string = '';
-      complete: boolean = true; // Simulate instant load
-      constructor() {
-        setTimeout(() => this.onload && this.onload(), 10);
-      }
-    } as any;
-
     const config: QRConfig = {
       ...DEFAULT_CONFIG,
       isBorderEnabled: true,
@@ -113,14 +115,10 @@ describe('QRCanvas Border Extended Features', () => {
     };
 
     render(<QRCanvas config={config} size={100} />);
-    await new Promise((resolve) => setTimeout(resolve, 200));
 
-    // drawImage called twice? Once for main QR (if any) and one for border.
-    // Default config has no logoUrl, but has borderLogoUrl.
-    // So drawImage should be called once.
-    expect(mockContext.drawImage).toHaveBeenCalled();
-
-    window.Image = originalImage;
-    document.createElement = originalCreateElement;
+    // Wait for image to load and draw
+    await waitFor(() => {
+      expect(mockContext.drawImage).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
This PR addresses test reliability issues in `src/components/QRCanvasExtended.test.tsx` by replacing flaky `setTimeout` calls with deterministic `waitFor` assertions and improving the mocking strategy for Canvas and Image APIs.

Changes:
- Modified `src/components/QRCanvasExtended.test.tsx` to use `waitFor` instead of `setTimeout`.
- Refactored `document.createElement` mocking to use `vi.spyOn`.
- Added journal entry in `.jules/shield.md`.

---
*PR created automatically by Jules for task [4421282439377188013](https://jules.google.com/task/4421282439377188013) started by @fderuiter*