### PR TITLE
⚡ Bolt: Batch Render HIVE and STARBURST Styles

### DIFF
--- a/src/components/QRCanvas.tsx
+++ b/src/components/QRCanvas.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { QRConfig, QRStyle } from '../types';
-import { drawRoundRect, drawPoly, drawStar, drawRoughRect, drawScribble } from '../utils/canvasHelpers';
+import { drawRoundRect, drawPoly, drawStar, drawRoughRect, drawScribble, drawPolyPath, drawStarPath } from '../utils/canvasHelpers';
 
 /**
  * Props for the QRCanvas component.
@@ -385,7 +385,7 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
         ctx.fillStyle = config.fgColor;
 
         // Optimization: Batch drawing for compatible styles to reduce draw calls
-        const isBatchable = [QRStyle.STANDARD, QRStyle.MODERN, QRStyle.SWISS, QRStyle.FLUID].includes(config.style);
+        const isBatchable = [QRStyle.STANDARD, QRStyle.MODERN, QRStyle.SWISS, QRStyle.FLUID, QRStyle.HIVE, QRStyle.STARBURST].includes(config.style);
 
         if (isBatchable) {
             ctx.beginPath();
@@ -416,6 +416,12 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
                            ctx.moveTo(cx + (cellSize/2 * 1.1), cy);
                            ctx.arc(cx, cy, cellSize/2 * 1.1, 0, Math.PI*2);
                            break;
+                       case QRStyle.HIVE:
+                           drawPolyPath(ctx, cx, cy, cellSize/1.55, 6, 0);
+                           break;
+                       case QRStyle.STARBURST:
+                           drawStarPath(ctx, cx, cy, cellSize/1.5, cellSize/2.2, 5);
+                           break;
                        case QRStyle.STANDARD:
                        default:
                            ctx.rect(Math.floor(x), Math.floor(y), Math.ceil(cellSize), Math.ceil(cellSize));
@@ -442,17 +448,9 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
                         if (hasLeft) ctx.fillRect(x, cy - thickness/2, cellSize/2 + 1, thickness);
                         if (hasTop) ctx.fillRect(cx - thickness/2, y, thickness, cellSize/2 + 1);
                         break;
-                      case QRStyle.HIVE:
-                        // Massive Hexagon
-                        drawPoly(ctx, cx, cy, cellSize/1.55, 6, 0, true);
-                        break;
                       case QRStyle.GRUNGE:
                         // Full size rough rect, minimal jitter
                         drawRoughRect(ctx, x, y, cellSize, cellSize);
-                        break;
-                      case QRStyle.STARBURST:
-                         // Fat star - nearly a square
-                        drawStar(ctx, cx, cy, cellSize/1.5, cellSize/2.2, 5, true);
                         break;
                   }
               }

--- a/src/components/QRCanvasBatching.test.tsx
+++ b/src/components/QRCanvasBatching.test.tsx
@@ -1,0 +1,134 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach, Mock } from 'vitest';
+import QRCanvas from './QRCanvas';
+import { DEFAULT_CONFIG } from '../constants';
+import { QRStyle } from '../types';
+import QRCode from 'qrcode';
+
+// Mock qrcode module
+vi.mock('qrcode', () => {
+  const createMock = vi.fn();
+  return {
+    create: createMock,
+    default: {
+      create: createMock,
+    },
+  };
+});
+
+// Mock Image
+const originalImage = window.Image;
+
+describe('QRCanvas Batch Rendering', () => {
+  let mockContext: any;
+  let mockModules: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockContext = {
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      roundRect: vi.fn(),
+      beginPath: vi.fn(),
+      fill: vi.fn(),
+      arc: vi.fn(),
+      rect: vi.fn(),
+      save: vi.fn(),
+      translate: vi.fn(),
+      rotate: vi.fn(),
+      restore: vi.fn(),
+      scale: vi.fn(),
+      drawImage: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      setLineDash: vi.fn(),
+      strokeRect: vi.fn(),
+      stroke: vi.fn(),
+      fillText: vi.fn(),
+      canvas: { width: 0, height: 0 },
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 0,
+      font: '',
+      textAlign: '',
+      textBaseline: '',
+    };
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation((contextId) => {
+      if (contextId === '2d') {
+        return mockContext;
+      }
+      return null;
+    });
+
+    const size = 21;
+    mockModules = {
+      size: size,
+      get: vi.fn().mockReturnValue(false),
+    };
+
+    (QRCode.create as unknown as Mock).mockReturnValue({
+      modules: mockModules,
+    });
+
+    window.Image = class {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      src = '';
+      complete = false;
+      crossOrigin = '';
+    } as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.Image = originalImage;
+  });
+
+  const setModules = (indices: [number, number][]) => {
+      mockModules.get.mockImplementation((row: number, col: number) => {
+          return indices.some(([r, c]) => r === row && c === col);
+      });
+  };
+
+  it('batches HIVE style rendering (few fill calls for many modules)', async () => {
+      // Set multiple modules active (not eyes)
+      // Eyes are at (0-6, 0-6), (0-6, 14-20), (14-20, 0-6)
+      // (10, 10) is safe.
+      setModules([[10, 10], [10, 11], [11, 10], [11, 11]]);
+      const config = { ...DEFAULT_CONFIG, style: QRStyle.HIVE };
+      render(<QRCanvas config={config} />);
+
+      await waitFor(() => {
+          // Expected Fills:
+          // 1. Batched modules (all 4 in one path) -> 1 call
+          // 2. Eyes: 3 eyes. HIVE eye pupil uses drawPoly(fill=true). Frame/Hole use fillRect.
+          // So 3 calls for eyes.
+          // Total = 4.
+          expect(mockContext.fill).toHaveBeenCalledTimes(4);
+
+          // Verify path construction happened
+          expect(mockContext.lineTo.mock.calls.length).toBeGreaterThan(20);
+      });
+  });
+
+  it('batches STARBURST style rendering', async () => {
+      setModules([[10, 10], [10, 11], [11, 10], [11, 11]]);
+      const config = { ...DEFAULT_CONFIG, style: QRStyle.STARBURST };
+      render(<QRCanvas config={config} />);
+
+      await waitFor(() => {
+          // Expected Fills:
+          // 1. Batched modules -> 1 call
+          // 2. Eyes: 3 eyes. STARBURST eye pupil uses drawStar(fill=true). Frame/Hole use fillRect.
+          // So 3 calls for eyes.
+          // Total = 4.
+          expect(mockContext.fill).toHaveBeenCalledTimes(4);
+
+          expect(mockContext.lineTo.mock.calls.length).toBeGreaterThan(40);
+      });
+  });
+});

--- a/src/utils/canvasHelpers.test.ts
+++ b/src/utils/canvasHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { drawRoundRect, drawPoly, drawStar, drawRoughRect, drawScribble } from './canvasHelpers';
+import { drawRoundRect, drawPoly, drawPolyPath, drawStar, drawStarPath, drawRoughRect, drawScribble } from './canvasHelpers';
 
 describe('canvasHelpers', () => {
   let ctx: any;
@@ -68,6 +68,20 @@ describe('canvasHelpers', () => {
     });
   });
 
+  describe('drawPolyPath', () => {
+    it('should draw a polygon path without starting path or filling', () => {
+      const sides = 6;
+      drawPolyPath(ctx, 50, 50, 20, sides);
+
+      expect(ctx.beginPath).not.toHaveBeenCalled();
+      expect(ctx.moveTo).toHaveBeenCalledTimes(1);
+      expect(ctx.lineTo).toHaveBeenCalledTimes(sides - 1);
+      expect(ctx.closePath).toHaveBeenCalled();
+      expect(ctx.fill).not.toHaveBeenCalled();
+      expect(ctx.stroke).not.toHaveBeenCalled();
+    });
+  });
+
   describe('drawStar', () => {
     it('should draw a star with correct spikes', () => {
       const spikes = 5;
@@ -87,6 +101,20 @@ describe('canvasHelpers', () => {
       drawStar(ctx, 50, 50, 20, 10, 5, false);
       expect(ctx.fill).not.toHaveBeenCalled();
       expect(ctx.stroke).toHaveBeenCalled();
+    });
+  });
+
+  describe('drawStarPath', () => {
+    it('should draw a star path without starting path or filling', () => {
+      const spikes = 5;
+      drawStarPath(ctx, 50, 50, 20, 10, spikes);
+
+      expect(ctx.beginPath).not.toHaveBeenCalled();
+      expect(ctx.moveTo).toHaveBeenCalledTimes(1);
+      expect(ctx.lineTo).toHaveBeenCalledTimes((spikes * 2) + 1);
+      expect(ctx.closePath).toHaveBeenCalled();
+      expect(ctx.fill).not.toHaveBeenCalled();
+      expect(ctx.stroke).not.toHaveBeenCalled();
     });
   });
 

--- a/src/utils/canvasHelpers.ts
+++ b/src/utils/canvasHelpers.ts
@@ -39,6 +39,20 @@ export const drawRoundRect = (ctx: CanvasRenderingContext2D, x: number, y: numbe
  */
 export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r: number, sides: number, rotate: number = 0, fill: boolean = true) => {
   ctx.beginPath();
+  drawPolyPath(ctx, x, y, r, sides, rotate);
+  if (fill) ctx.fill(); else ctx.stroke();
+};
+
+/**
+ * Draws a regular polygon path (no fill/stroke).
+ * @param ctx The canvas context.
+ * @param x The center x coordinate.
+ * @param y The center y coordinate.
+ * @param r The radius.
+ * @param sides The number of sides.
+ * @param rotate Rotation angle in radians (default: 0).
+ */
+export const drawPolyPath = (ctx: CanvasRenderingContext2D, x: number, y: number, r: number, sides: number, rotate: number = 0) => {
   for (let i = 0; i < sides; i++) {
     const theta = rotate + (i * 2 * Math.PI / sides);
     const px = x + r * Math.cos(theta);
@@ -47,7 +61,6 @@ export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r:
     else ctx.lineTo(px, py);
   }
   ctx.closePath();
-  if (fill) ctx.fill(); else ctx.stroke();
 };
 
 /**
@@ -61,12 +74,26 @@ export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r:
  * @param fill Whether to fill the star (default: true).
  */
 export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, outerR: number, innerR: number, spikes: number, fill: boolean = true) => {
+  ctx.beginPath();
+  drawStarPath(ctx, cx, cy, outerR, innerR, spikes);
+  if (fill) ctx.fill(); else ctx.stroke();
+};
+
+/**
+ * Draws a star path (no fill/stroke).
+ * @param ctx The canvas context.
+ * @param cx The center x coordinate.
+ * @param cy The center y coordinate.
+ * @param outerR The outer radius.
+ * @param innerR The inner radius.
+ * @param spikes The number of spikes.
+ */
+export const drawStarPath = (ctx: CanvasRenderingContext2D, cx: number, cy: number, outerR: number, innerR: number, spikes: number) => {
   let rot = Math.PI / 2 * 3;
   let x = cx;
   let y = cy;
   const step = Math.PI / spikes;
 
-  ctx.beginPath();
   ctx.moveTo(cx, cy - outerR);
   for (let i = 0; i < spikes; i++) {
     x = cx + Math.cos(rot) * outerR;
@@ -81,7 +108,6 @@ export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, 
   }
   ctx.lineTo(cx, cy - outerR);
   ctx.closePath();
-  if (fill) ctx.fill(); else ctx.stroke();
 };
 
 /**


### PR DESCRIPTION
This PR optimizes the rendering performance of the `QRCanvas` component for `HIVE` and `STARBURST` styles. Previously, these styles issued individual `fill` calls for every module (dot) in the QR code, leading to thousands of draw calls for complex codes. This change implements batch rendering by constructing a single path for all modules and filling them at once, similar to how standard styles were already optimized.

Key changes:
- Added `drawPolyPath` and `drawStarPath` to `src/utils/canvasHelpers.ts` which perform path operations (`moveTo`, `lineTo`) without starting a new path or filling.
- Updated `src/components/QRCanvas.tsx` to use these new helpers for `HIVE` and `STARBURST` styles and enabled them in the `isBatchable` check.
- Added `src/components/QRCanvasBatching.test.tsx` to verify that `ctx.fill` is called significantly fewer times (once for modules + eyes) instead of once per module.
- `QRStyle.GRUNGE` remains unbatched due to its reliance on individual rotation transformations.

---
*PR created automatically by Jules for task [5058514416406766460](https://jules.google.com/task/5058514416406766460) started by @fderuiter*