### PR TITLE
🎨 Palette: Add character count to text inputs

### DIFF
--- a/src/components/CharCount.test.tsx
+++ b/src/components/CharCount.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { CharCount } from './CharCount';
+
+describe('CharCount Component', () => {
+  it('renders correct count', () => {
+    render(<CharCount current={50} max={100} />);
+    expect(screen.getByText('50 / 100')).toBeInTheDocument();
+  });
+
+  it('renders default color for low usage', () => {
+    render(<CharCount current={10} max={100} />);
+    const counter = screen.getByText('10 / 100');
+    expect(counter).toHaveClass('text-slate-500');
+  });
+
+  it('renders warning color for >= 90% usage', () => {
+    render(<CharCount current={90} max={100} />);
+    const counter = screen.getByText('90 / 100');
+    expect(counter).toHaveClass('text-amber-600');
+  });
+
+  it('renders error color for 100% usage', () => {
+    render(<CharCount current={100} max={100} />);
+    const counter = screen.getByText('100 / 100');
+    expect(counter).toHaveClass('text-rose-600');
+  });
+
+  it('has accessibility attributes', () => {
+    render(<CharCount current={50} max={100} />);
+    const counter = screen.getByText('50 / 100');
+    expect(counter).toHaveAttribute('aria-live', 'polite');
+    expect(counter).toHaveAttribute('aria-atomic', 'true');
+  });
+});

--- a/src/components/CharCount.tsx
+++ b/src/components/CharCount.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface CharCountProps {
+  current: number;
+  max: number;
+}
+
+export const CharCount: React.FC<CharCountProps> = ({ current, max }) => {
+  const percentage = (current / max) * 100;
+
+  let colorClass = "text-slate-500 dark:text-slate-400";
+  if (percentage >= 100) {
+    colorClass = "text-rose-600 dark:text-rose-500 font-medium";
+  } else if (percentage >= 90) {
+    colorClass = "text-amber-600 dark:text-amber-500";
+  }
+
+  return (
+    <div
+      className={`text-xs text-right mt-1 transition-colors duration-200 ${colorClass}`}
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {current} / {max}
+    </div>
+  );
+};

--- a/src/components/InputPanel.test.tsx
+++ b/src/components/InputPanel.test.tsx
@@ -317,4 +317,9 @@ describe('InputPanel Component', () => {
     // Should output raw address/string
     expect(mockOnChange).toHaveBeenLastCalledWith({ value: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa' });
   });
+
+  it('shows character count for TEXT input', () => {
+      renderPanel({ type: QRType.TEXT, value: 'Hello' });
+      expect(screen.getByText('5 / 2500')).toBeInTheDocument();
+  });
 });

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -11,6 +11,7 @@ import {
   isDangerousUrl
 } from '../utils/qrHelpers';
 import { useQRInputState } from '../utils/hooks';
+import { CharCount } from './CharCount';
 
 /**
  * Props for the InputPanel component.
@@ -144,6 +145,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
               value={config.value}
               onChange={(e) => onChange({ value: e.target.value })}
             />
+            <CharCount current={config.value.length} max={2500} />
           </div>
         )}
 
@@ -268,6 +270,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                         onChange={(e) => handleEmailChange({ body: e.target.value })}
                         className={textAreaClasses}
                     />
+                    <CharCount current={emailData.body.length} max={2000} />
                 </div>
             </div>
         )}
@@ -433,6 +436,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                         onChange={(e) => handleSmsChange({ message: e.target.value })}
                         className={textAreaClasses}
                     />
+                    <CharCount current={smsData.message.length} max={1600} />
                 </div>
             </div>
         )}


### PR DESCRIPTION
Added a `CharCount` component to provide visual feedback for text-heavy inputs (Text, SMS, Email). This improves UX by warning users as they approach character limits. The component uses accessible ARIA attributes and color-coded warnings (Amber for 90%, Red for 100%). Confirmed with tests and visual inspection.

---
*PR created automatically by Jules for task [17708633409267952404](https://jules.google.com/task/17708633409267952404) started by @fderuiter*