### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Simple protocol checks (like `.startsWith('javascript:')`) can be bypassed using control characters or whitespace (e.g., `j a v a s c r i p t :` or `\njavascript:`).
 **Learning:** Browser URL parsers often strip whitespace and control characters before processing the scheme, meaning a "safe" string to a regex might still execute code.
 **Prevention:** Always normalize inputs by stripping all whitespace and control characters before validating the protocol scheme.
+
+## 2025-02-18 - CSP Meta Tag Limitations
+**Discovery:** Content Security Policy (CSP) delivered via `<meta>` tag ignores the `frame-ancestors` directive.
+**Learning:** `frame-ancestors` must be delivered via HTTP headers to be effective against Clickjacking. Using it in a meta tag provides false security.
+**Prevention:** Do not rely on `<meta>` tags for Clickjacking protection. Use HTTP headers or legacy frame-busting scripts if headers are not controllable (e.g. static hosting without header config).

--- a/src/layouts/Head.test.tsx
+++ b/src/layouts/Head.test.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import HeadDefault from './Head';
+
+// Mock usePageContext since it's used in HeadDefault
+vi.mock('vike-react/usePageContext', () => ({
+  usePageContext: () => ({
+    urlPathname: '/',
+    config: {
+      title: 'Test Title',
+      description: 'Test Desc'
+    }
+  })
+}));
+
+describe('HeadDefault', () => {
+  it('includes a Content Security Policy (CSP) meta tag', () => {
+    // Render into document.head because meta tags are only valid there
+    const { container } = render(<HeadDefault />, { container: document.head });
+
+    // Note: container will be document.head
+
+    const metaCSP = container.querySelector('meta[http-equiv="Content-Security-Policy"]');
+    expect(metaCSP).toBeInTheDocument();
+
+    const content = metaCSP?.getAttribute('content') || '';
+
+    expect(content).toContain("default-src 'self'");
+    expect(content).toContain("object-src 'none'");
+    expect(content).toContain("base-uri 'self'");
+    expect(content).toContain("upgrade-insecure-requests");
+
+    expect(content).toContain("script-src 'self' 'unsafe-inline'");
+    expect(content).toContain("style-src 'self' 'unsafe-inline' https://fonts.googleapis.com");
+    expect(content).toContain("font-src 'self' https://fonts.gstatic.com");
+    expect(content).toContain("img-src 'self' data:");
+  });
+});

--- a/src/layouts/Head.tsx
+++ b/src/layouts/Head.tsx
@@ -92,6 +92,14 @@ export default function HeadDefault() {
   return (
     <>
       {/*
+        Content Security Policy (CSP)
+        - script-src 'unsafe-inline': Required for JSON-LD scripts and Vike hydration in SSG.
+        - style-src 'unsafe-inline': Required for the font loading hack and CSS extraction.
+        - object-src 'none': Prevents Flash/Java applets.
+      */}
+      <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" />
+
+      {/*
         Note: 'viewport' and 'description' are handled by Vike/Config to avoid duplicates.
         Build output confirmed Vike injects: <meta name="viewport" content="width=device-width,initial-scale=1">
 


### PR DESCRIPTION
Implemented Content Security Policy (CSP) as a security enhancement.
- Added `<meta httpEquiv="Content-Security-Policy" ...>` to `src/layouts/Head.tsx`.
- Created `src/layouts/Head.test.tsx` to verify the CSP tag presence and directives.
- Ensured the policy allows necessary resources (Google Fonts, inline scripts/styles for React/Vike).
- Documented learning about `frame-ancestors` in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6743997888014914834](https://jules.google.com/task/6743997888014914834) started by @fderuiter*