### PR TITLE
🧹 Polish: Decouple qrHelpers from security module

### DIFF
--- a/.jules/polish.md
+++ b/.jules/polish.md
@@ -1,3 +1,7 @@
 ## 2024-05-22 - [Magic Strings in Data Types]
 **Smell:** Primitive Obsession - hardcoded string literals (e.g., 'WPA', 'nopass') used repeatedly across types, components, and helpers.
 **Remedy:** Extract to shared Enums (e.g., `WifiEncryption`) to enforce consistency and enable safe refactoring.
+
+## 2024-05-23 - [Implicit Module Coupling]
+**Smell:** Utility modules re-exporting functions from other utilities (Facade pattern in the same layer), creating ambiguous sources of truth.
+**Remedy:** Import directly from the canonical source module to make dependencies explicit and reduce circular references.

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -7,9 +7,9 @@ import {
   constructVCardString,
   constructPhoneString,
   constructSmsString,
-  constructPaymentString,
-  isDangerousUrl
+  constructPaymentString
 } from '../utils/qrHelpers';
+import { isDangerousUrl } from '../utils/security';
 import { useQRInputState } from '../utils/hooks';
 import { CharCount } from './CharCount';
 

--- a/src/utils/qrHelpers.ts
+++ b/src/utils/qrHelpers.ts
@@ -1,6 +1,5 @@
 import { WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption } from '../types';
 import { isDangerousUrl, cleanPhoneNumber } from './security';
-export { isDangerousUrl, cleanPhoneNumber };
 
 /**
  * Escapes special characters for WiFi QR code string.


### PR DESCRIPTION
Decoupled `qrHelpers.ts` from `security.ts` by removing re-exports of `isDangerousUrl` and `cleanPhoneNumber`. Updated `InputPanel.tsx` to import `isDangerousUrl` directly from `security.ts`. This clarifies dependencies and reduces module coupling. Validated with tests.

---
*PR created automatically by Jules for task [8336665311468156245](https://jules.google.com/task/8336665311468156245) started by @fderuiter*