### PR TITLE
🛡️ Shield: Fix false positive contrast warnings for 3-digit hex codes

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -15,3 +15,7 @@
 ## 2025-02-18 - Flaky Canvas Tests with setTimeout
 **Discovery:** `QRCanvasExtended.test.tsx` used hardcoded `setTimeout` delays (100ms, 200ms) to wait for async canvas rendering. This causes flakiness if the environment is slow, or wastes time if it's fast. It also triggered `act(...)` warnings because state updates happened outside React's test loop.
 **Defense:** Replaced `setTimeout` with `waitFor` from `@testing-library/react`. This makes the test deterministic, faster, and implicitly handles async state updates correctly.
+
+## 2025-02-18 - Unsupported 3-digit Hex in Color Utils
+**Discovery:** `getContrastRatio` treated valid 3-digit hex codes (e.g., `#FFF`) as invalid inputs, returning 0 contrast. This caused false positive "Low Contrast" warnings in the UI when users manually entered short hex codes.
+**Defense:** Updated `getLuminance` to expand 3-digit hex codes to 6-digit equivalents and updated `getContrastRatio` to validate and accept length-4 hex strings.

--- a/src/utils/colorUtils.test.ts
+++ b/src/utils/colorUtils.test.ts
@@ -12,6 +12,13 @@ describe('colorUtils', () => {
       expect(getLuminance('#000000')).toBe(0);
     });
 
+    it('calculates correct luminance for 3-digit hex', () => {
+      expect(getLuminance('#fff')).toBeCloseTo(1, 4);
+      expect(getLuminance('#FFF')).toBeCloseTo(1, 4);
+      expect(getLuminance('#000')).toBe(0);
+      expect(getLuminance('#F00')).toBeCloseTo(0.2126, 4); // Red
+    });
+
     it('calculates correct luminance for primary red', () => {
       // sRGB Red relative luminance is approx 0.2126
       expect(getLuminance('#FF0000')).toBeCloseTo(0.2126, 4);
@@ -39,16 +46,23 @@ describe('colorUtils', () => {
       expect(contrast).toBeCloseTo(21, 1);
     });
 
+    it('supports 3-digit hex codes', () => {
+      expect(getContrastRatio('#fff', '#000')).toBeCloseTo(21, 1);
+      expect(getContrastRatio('#000', '#fff')).toBeCloseTo(21, 1);
+      expect(getContrastRatio('#fff', '#000000')).toBeCloseTo(21, 1);
+      // Mixed length
+      expect(getContrastRatio('#F00', '#000000')).toBeCloseTo(5.25, 2); // Red on Black
+    });
+
     it('returns 1 for same colors', () => {
       expect(getContrastRatio('#ffffff', '#ffffff')).toBe(1);
       expect(getContrastRatio('#000000', '#000000')).toBe(1);
       expect(getContrastRatio('#123456', '#123456')).toBe(1);
+      expect(getContrastRatio('#123', '#123')).toBe(1);
     });
 
     it('returns 0 for invalid inputs', () => {
       // Test length checks
-      expect(getContrastRatio('#fff', '#000000')).toBe(0); // 3-digit hex
-      expect(getContrastRatio('#000000', '#fff')).toBe(0);
       expect(getContrastRatio('', '#000000')).toBe(0);
 
       // We can't easily test null/undefined types in TS without casting,
@@ -58,11 +72,12 @@ describe('colorUtils', () => {
     });
 
     it('returns 0 for non-hex characters', () => {
-      // #GGGGGG is invalid but has length 7. Currently it silently returns 21 (black).
-      // We want it to be 0 to indicate failure.
+      // #GGGGGG is invalid but has length 7.
       expect(getContrastRatio('#GGGGGG', '#FFFFFF')).toBe(0);
       expect(getContrastRatio('#FFFFFF', '#GGGGGG')).toBe(0);
       expect(getContrastRatio('#12345Z', '#FFFFFF')).toBe(0);
+      // Invalid 3-digit-like
+      expect(getContrastRatio('#GGG', '#FFFFFF')).toBe(0);
     });
 
     it('calculates WCAG 2.0 contrast ratio correctly', () => {

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,11 +1,16 @@
 /**
  * Utility to calculate relative luminance of a color.
  * Used for contrast ratio calculation.
- * @param hex - The hex color code (e.g. #RRGGBB).
+ * @param hex - The hex color code (e.g. #RRGGBB or #RGB).
  * @returns The relative luminance value.
  */
 export const getLuminance = (hex: string) => {
-  const rgb = parseInt(hex.slice(1), 16);
+  let normalizedHex = hex;
+  if (hex.length === 4) {
+    normalizedHex = '#' + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3];
+  }
+
+  const rgb = parseInt(normalizedHex.slice(1), 16);
   const r = ((rgb >> 16) & 0xff) / 255;
   const g = ((rgb >> 8) & 0xff) / 255;
   const b = (rgb & 0xff) / 255;
@@ -23,8 +28,12 @@ export const getLuminance = (hex: string) => {
  * @returns The contrast ratio (1 to 21).
  */
 export const getContrastRatio = (fg: string, bg: string) => {
-  if (!fg || !bg || fg.length !== 7 || bg.length !== 7) return 0;
-  if (!/^#[0-9A-Fa-f]{6}$/.test(fg) || !/^#[0-9A-Fa-f]{6}$/.test(bg)) return 0;
+  if (!fg || !bg) return 0;
+  if ((fg.length !== 7 && fg.length !== 4) || (bg.length !== 7 && bg.length !== 4)) return 0;
+
+  const hexRegex = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
+  if (!hexRegex.test(fg) || !hexRegex.test(bg)) return 0;
+
   const l1 = getLuminance(fg);
   const l2 = getLuminance(bg);
   const lighter = Math.max(l1, l2);


### PR DESCRIPTION
🛑 **Vulnerability:** `getContrastRatio` treated valid 3-digit hex codes (e.g., `#FFF`) as invalid, returning 0 contrast. This caused false positive "Low Contrast" warnings in the UI if users managed to input short codes (or via future API/presets).
🛡️ **Defense:** Updated `getLuminance` to expand 3-digit hex to 6-digit. Updated `getContrastRatio` regex to accept length 4. Added dedicated unit tests in `src/utils/colorUtils.test.ts`.
🔬 **Verification:** `npm test -- run src/utils/colorUtils.test.ts` passes. Playwright script confirmed fix prevents warning when using `#FFF`.
📊 **Impact:** Increases robustness of color utilities and prevents misleading UI warnings. Adds missing unit test coverage for core utility.

---
*PR created automatically by Jules for task [11822841827732634311](https://jules.google.com/task/11822841827732634311) started by @fderuiter*