### PR TITLE
🎨 Palette: Add visible labels to vCard address fields

### DIFF
--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -383,10 +383,19 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                  <fieldset className="pt-2 border-t border-slate-100 dark:border-slate-800 min-w-0">
                     <legend className="block text-xs font-bold text-slate-600 dark:text-slate-400 mb-2 w-full">Address</legend>
                     <div className="space-y-3">
-                        <input aria-label="Street" name="street" autoComplete="street-address" type="text" maxLength={100} placeholder="Street" value={vCardData.street} onChange={(e) => handleVCardChange({ street: e.target.value })} className={inputClasses} />
+                        <div>
+                           <label htmlFor="vcard-street" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Street</label>
+                           <input id="vcard-street" name="street" autoComplete="street-address" type="text" maxLength={100} placeholder="Street" value={vCardData.street} onChange={(e) => handleVCardChange({ street: e.target.value })} className={inputClasses} />
+                        </div>
                         <div className="grid grid-cols-2 gap-3">
-                             <input aria-label="City" name="city" autoComplete="address-level2" type="text" maxLength={100} placeholder="City" value={vCardData.city} onChange={(e) => handleVCardChange({ city: e.target.value })} className={inputClasses} />
-                             <input aria-label="Country" name="country" autoComplete="country-name" type="text" maxLength={100} placeholder="Country" value={vCardData.country} onChange={(e) => handleVCardChange({ country: e.target.value })} className={inputClasses} />
+                            <div>
+                               <label htmlFor="vcard-city" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">City</label>
+                               <input id="vcard-city" name="city" autoComplete="address-level2" type="text" maxLength={100} placeholder="City" value={vCardData.city} onChange={(e) => handleVCardChange({ city: e.target.value })} className={inputClasses} />
+                            </div>
+                            <div>
+                               <label htmlFor="vcard-country" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Country</label>
+                               <input id="vcard-country" name="country" autoComplete="country-name" type="text" maxLength={100} placeholder="Country" value={vCardData.country} onChange={(e) => handleVCardChange({ country: e.target.value })} className={inputClasses} />
+                            </div>
                         </div>
                     </div>
                  </fieldset>

--- a/src/components/InputPanel_UX.test.tsx
+++ b/src/components/InputPanel_UX.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import InputPanel from './InputPanel';
+import { DEFAULT_CONFIG } from '../constants';
+import { QRType } from '../types';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('InputPanel UX', () => {
+  const mockOnChange = vi.fn();
+
+  it('renders visible labels for vCard address fields', () => {
+    render(<InputPanel config={{ ...DEFAULT_CONFIG, type: QRType.VCARD }} onChange={mockOnChange} />);
+
+    // These should exist as visible <label> elements
+    // Currently they do not (they are aria-labels on inputs)
+    expect(screen.getByText('Street', { selector: 'label' })).toBeInTheDocument();
+    expect(screen.getByText('City', { selector: 'label' })).toBeInTheDocument();
+    expect(screen.getByText('Country', { selector: 'label' })).toBeInTheDocument();
+
+    // Also verify they are associated with inputs
+    const streetLabel = screen.getByText('Street', { selector: 'label' });
+    const streetInput = screen.getByLabelText('Street');
+    expect(streetLabel.getAttribute('for')).toBe(streetInput.id);
+  });
+});


### PR DESCRIPTION
This PR improves the UX and accessibility of the vCard address inputs by adding visible labels.

**Changes:**
- Replaced `aria-label` only inputs with standard `label` + `input` pairs for Street, City, and Country.
- Applied consistent Tailwind styling (`text-xs font-medium text-slate-500`) to match other vCard fields like "First Name".
- Added `src/components/InputPanel_UX.test.tsx` to verify the presence and association of these labels.

**Why:**
- "Good UX Code" requires form fields to have proper labels.
- Placeholders disappear when typing, losing context for the user.
- Consistency with other fields in the "Contact Details" section.

**Verification:**
- Validated with `npm test`.
- Verified visually with Playwright screenshot showing the new labels appearing correctly under the "Address" section.

---
*PR created automatically by Jules for task [978273472960718673](https://jules.google.com/task/978273472960718673) started by @fderuiter*