### PR TITLE
⚡ Bolt: Batch rendering for Hive and Starburst QR styles

### DIFF
--- a/src/components/InputPanel.test.tsx
+++ b/src/components/InputPanel.test.tsx
@@ -239,7 +239,7 @@ describe('InputPanel Component', () => {
       fireEvent.change(msgInput, { target: { value: 'Hello there' } });
       act(() => { vi.advanceTimersByTime(100); });
 
-      expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'smsto:+1234567890:Hello there' });
+      expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'sms:+1234567890?body=Hello%20there' });
   });
 
   it('formats vCard correctly', () => {

--- a/src/components/InputPanel_EdgeCases.test.tsx
+++ b/src/components/InputPanel_EdgeCases.test.tsx
@@ -88,9 +88,9 @@ describe('InputPanel Edge Cases', () => {
     fireEvent.change(msgInput, { target: { value: 'Time: 12:30 PM' } });
     act(() => { vi.advanceTimersByTime(100); });
 
-    // Format: smsto:number:message
-    // Colons in message should be preserved as-is
-    expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'smsto:123:Time: 12:30 PM' });
+    // Format: sms:number?body=message
+    // Colons in message should be encoded
+    expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'sms:123?body=Time%3A%2012%3A30%20PM' });
   });
 
   it('escapes special characters in WPA2-EAP Identity', () => {

--- a/src/components/QRCanvas.tsx
+++ b/src/components/QRCanvas.tsx
@@ -385,7 +385,7 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
         ctx.fillStyle = config.fgColor;
 
         // Optimization: Batch drawing for compatible styles to reduce draw calls
-        const isBatchable = [QRStyle.STANDARD, QRStyle.MODERN, QRStyle.SWISS, QRStyle.FLUID, QRStyle.CIRCUIT].includes(config.style);
+        const isBatchable = [QRStyle.STANDARD, QRStyle.MODERN, QRStyle.SWISS, QRStyle.FLUID, QRStyle.CIRCUIT, QRStyle.HIVE, QRStyle.STARBURST].includes(config.style);
 
         if (isBatchable) {
             ctx.beginPath();
@@ -434,6 +434,14 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
                              if (hasTop) ctx.rect(cx - thickness/2, y, thickness, cellSize/2 + 1);
                            }
                            break;
+                       case QRStyle.HIVE:
+                           // Massive Hexagon
+                           drawPoly(ctx, cx, cy, cellSize/1.55, 6, 0, true, true);
+                           break;
+                       case QRStyle.STARBURST:
+                           // Fat star - nearly a square
+                           drawStar(ctx, cx, cy, cellSize/1.5, cellSize/2.2, 5, true, true);
+                           break;
                        case QRStyle.STANDARD:
                        default:
                            ctx.rect(Math.floor(x), Math.floor(y), Math.ceil(cellSize), Math.ceil(cellSize));
@@ -441,17 +449,9 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
                    }
               } else {
                   switch(config.style) {
-                      case QRStyle.HIVE:
-                        // Massive Hexagon
-                        drawPoly(ctx, cx, cy, cellSize/1.55, 6, 0, true);
-                        break;
                       case QRStyle.GRUNGE:
                         // Full size rough rect, minimal jitter
                         drawRoughRect(ctx, x, y, cellSize, cellSize);
-                        break;
-                      case QRStyle.STARBURST:
-                         // Fat star - nearly a square
-                        drawStar(ctx, cx, cy, cellSize/1.5, cellSize/2.2, 5, true);
                         break;
                   }
               }

--- a/src/components/QRCanvasRendering.test.tsx
+++ b/src/components/QRCanvasRendering.test.tsx
@@ -225,4 +225,18 @@ describe('QRCanvas Rendering Logic Extended', () => {
          expect(mockContext.rotate).toHaveBeenCalled();
      });
   });
+
+  it('batches draw calls for HIVE style', async () => {
+      setModule(10, 10, true);
+      const config = { ...DEFAULT_CONFIG, style: QRStyle.HIVE };
+      render(<QRCanvas config={config} />);
+
+      await waitFor(() => {
+          // HIVE uses drawPoly with addToPath=true
+          // This should trigger moveTo/lineTo calls but NOT individual fills
+          expect(mockContext.moveTo).toHaveBeenCalled();
+          expect(mockContext.lineTo).toHaveBeenCalled();
+          expect(mockContext.fill).toHaveBeenCalled(); // Called once for the batch (plus eyes)
+      });
+  });
 });

--- a/src/utils/canvasHelpers.ts
+++ b/src/utils/canvasHelpers.ts
@@ -37,8 +37,8 @@ export const drawRoundRect = (ctx: CanvasRenderingContext2D, x: number, y: numbe
  * @param rotate Rotation angle in radians (default: 0).
  * @param fill Whether to fill the polygon (default: true).
  */
-export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r: number, sides: number, rotate: number = 0, fill: boolean = true) => {
-  ctx.beginPath();
+export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r: number, sides: number, rotate: number = 0, fill: boolean = true, addToPath: boolean = false) => {
+  if (!addToPath) ctx.beginPath();
   for (let i = 0; i < sides; i++) {
     const theta = rotate + (i * 2 * Math.PI / sides);
     const px = x + r * Math.cos(theta);
@@ -47,7 +47,9 @@ export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r:
     else ctx.lineTo(px, py);
   }
   ctx.closePath();
-  if (fill) ctx.fill(); else ctx.stroke();
+  if (!addToPath) {
+    if (fill) ctx.fill(); else ctx.stroke();
+  }
 };
 
 /**
@@ -60,13 +62,13 @@ export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r:
  * @param spikes The number of spikes.
  * @param fill Whether to fill the star (default: true).
  */
-export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, outerR: number, innerR: number, spikes: number, fill: boolean = true) => {
+export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, outerR: number, innerR: number, spikes: number, fill: boolean = true, addToPath: boolean = false) => {
   let rot = Math.PI / 2 * 3;
   let x = cx;
   let y = cy;
   const step = Math.PI / spikes;
 
-  ctx.beginPath();
+  if (!addToPath) ctx.beginPath();
   ctx.moveTo(cx, cy - outerR);
   for (let i = 0; i < spikes; i++) {
     x = cx + Math.cos(rot) * outerR;
@@ -81,7 +83,9 @@ export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, 
   }
   ctx.lineTo(cx, cy - outerR);
   ctx.closePath();
-  if (fill) ctx.fill(); else ctx.stroke();
+  if (!addToPath) {
+    if (fill) ctx.fill(); else ctx.stroke();
+  }
 };
 
 /**


### PR DESCRIPTION
This PR optimizes the rendering of `HIVE` and `STARBURST` QR styles by batching canvas draw calls. Previously, these styles executed a `ctx.fill()` for every module, causing performance degradation at higher resolutions. By using the new `addToPath` capability in helper functions, we now construct a single path for all modules and fill it once.

Also fixes existing tests for SMS QR codes to match the correct `sms:` URI scheme.

---
*PR created automatically by Jules for task [2227471277830268046](https://jules.google.com/task/2227471277830268046) started by @fderuiter*