### PR TITLE
🛡️ Sentinel: [HIGH] Fix phone parameter injection & update SMS tests

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The deprecated `smsto:` scheme was used without encoding the message body, allowing injection of delimiters (like `:`) to potentially alter the target number or break the URI.
 **Learning:** `smsto:` does not have a standard way to encode bodies. The standard `sms:` scheme supports `?body=` with URL-encoded values.
 **Prevention:** Use standard URI schemes (RFC 5724 for SMS) and always `encodeURIComponent` user-supplied data in URI parameters.
+
+## 2025-02-18 - Phone Number Injection
+**Vulnerability:** The `cleanPhoneNumber` function only removed spaces and colons, allowing attackers to inject URI parameters (like `?body=`) into `sms:` and `tel:` schemes.
+**Learning:** Blacklisting specific characters (like space and colon) is insufficient for security.
+**Prevention:** Use a whitelist approach for sanitization. For phone numbers, allow only digits and safe visual separators (`+`, `-`, `.`, `(`, `)`, `,`, `*`, `#`).

--- a/src/components/InputPanel.test.tsx
+++ b/src/components/InputPanel.test.tsx
@@ -239,7 +239,7 @@ describe('InputPanel Component', () => {
       fireEvent.change(msgInput, { target: { value: 'Hello there' } });
       act(() => { vi.advanceTimersByTime(100); });
 
-      expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'smsto:+1234567890:Hello there' });
+      expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'sms:+1234567890?body=Hello%20there' });
   });
 
   it('formats vCard correctly', () => {

--- a/src/components/InputPanel_EdgeCases.test.tsx
+++ b/src/components/InputPanel_EdgeCases.test.tsx
@@ -88,9 +88,9 @@ describe('InputPanel Edge Cases', () => {
     fireEvent.change(msgInput, { target: { value: 'Time: 12:30 PM' } });
     act(() => { vi.advanceTimersByTime(100); });
 
-    // Format: smsto:number:message
-    // Colons in message should be preserved as-is
-    expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'smsto:123:Time: 12:30 PM' });
+    // Format: sms:number?body=message
+    // Colons in message should be URL encoded
+    expect(mockOnChange).toHaveBeenLastCalledWith({ value: 'sms:123?body=Time%3A%2012%3A30%20PM' });
   });
 
   it('escapes special characters in WPA2-EAP Identity', () => {

--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -59,8 +59,27 @@ describe('Security Utils', () => {
   });
 
   describe('cleanPhoneNumber', () => {
-      it('removes spaces and colons', () => {
-          expect(cleanPhoneNumber('123 456:789')).toBe('123456789');
-      });
+    it('removes spaces and colons', () => {
+      expect(cleanPhoneNumber('123 456:789')).toBe('123456789');
+    });
+
+    it('allows valid phone characters', () => {
+      expect(cleanPhoneNumber('+1(555)123-4567')).toBe('+1(555)123-4567');
+      expect(cleanPhoneNumber('*#06#')).toBe('*#06#');
+      expect(cleanPhoneNumber('123,456')).toBe('123,456');
+    });
+
+    it('strips dangerous characters and letters', () => {
+      // 123?body=evil -> 123
+      expect(cleanPhoneNumber('123?body=evil')).toBe('123');
+      // 123;phone-context=evil -> 123-
+      expect(cleanPhoneNumber('123;phone-context=evil')).toBe('123-');
+      // 123&other=param -> 123
+      expect(cleanPhoneNumber('123&other=param')).toBe('123');
+    });
+
+    it('strips letters (vanity numbers)', () => {
+      expect(cleanPhoneNumber('1-800-FLOWERS')).toBe('1-800-');
+    });
   });
 });

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -30,8 +30,10 @@ export const isDangerousUrl = (url: string | undefined): boolean => {
 };
 
 /**
- * Removes spaces and colons from a phone number string.
+ * Cleans a phone number string by removing potentially dangerous characters.
+ * Allows digits, +, -, (, ), ., *, #, and ,
+ * Strips everything else to prevent parameter injection (e.g. ?body=)
  */
 export const cleanPhoneNumber = (number: string): string => {
-  return number.replace(/[\s:]+/g, '');
+  return number.replace(/[^0-9+\-().*#,]/g, '');
 };


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Parameter Injection in `cleanPhoneNumber`. The function only removed spaces and colons, allowing attackers to inject URI parameters (e.g., `?body=`) via the phone number input.
🎯 Impact: Attackers could manipulate SMS body content or other URI parameters when users scan a malicious QR code.
🔧 Fix:
1.  Enhanced `cleanPhoneNumber` in `src/utils/security.ts` to use a strict whitelist approach, allowing only digits and safe visual separators (`+`, `-`, `.`, `(`, `)`, `,`, `*`, `#`). Dangerous characters like `?`, `=`, `&`, and `;` are now stripped.
2.  Updated `src/components/InputPanel.test.tsx` and `src/components/InputPanel_EdgeCases.test.tsx` to align with the standard `sms:` URI scheme (RFC 5724) which is already implemented in `qrHelpers.ts`. The tests previously incorrectly expected the deprecated `smsto:` format.
✅ Verification:
-   Verified that `cleanPhoneNumber` strips dangerous characters.
-   Verified that all InputPanel tests pass with the correct `sms:` URI format.

---
*PR created automatically by Jules for task [2910680696470119540](https://jules.google.com/task/2910680696470119540) started by @fderuiter*