### PR TITLE
🧹 Polish: Introduce CryptoNetwork Enum

### DIFF
--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { QRConfig, QRType, WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption } from '../types';
+import { QRConfig, QRType, WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption, CryptoNetwork } from '../types';
 import { Wifi, Link, Type, Mail, UserSquare2, Phone, MessageSquare, CreditCard, Eye, EyeOff } from 'lucide-react';
 import {
   constructWifiString,
@@ -67,7 +67,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
   );
 
   const [paymentData, handlePaymentChange] = useQRInputState<PaymentData>(
-    { network: 'bitcoin', address: '', amount: '', label: '' },
+    { network: CryptoNetwork.BITCOIN, address: '', amount: '', label: '' },
     constructPaymentString,
     onChange
   );
@@ -284,14 +284,14 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                     <select
                       id="payment-network"
                       value={paymentData.network}
-                      onChange={(e) => handlePaymentChange({ network: e.target.value })}
+                      onChange={(e) => handlePaymentChange({ network: e.target.value as CryptoNetwork })}
                       className={selectClasses}
                     >
-                      <option value="bitcoin">Bitcoin (BTC)</option>
-                      <option value="ethereum">Ethereum (ETH)</option>
-                      <option value="solana">Solana (SOL)</option>
-                      <option value="litecoin">Litecoin (LTC)</option>
-                      <option value="custom">Custom / Raw Address</option>
+                      <option value={CryptoNetwork.BITCOIN}>Bitcoin (BTC)</option>
+                      <option value={CryptoNetwork.ETHEREUM}>Ethereum (ETH)</option>
+                      <option value={CryptoNetwork.SOLANA}>Solana (SOL)</option>
+                      <option value={CryptoNetwork.LITECOIN}>Litecoin (LTC)</option>
+                      <option value={CryptoNetwork.CUSTOM}>Custom / Raw Address</option>
                     </select>
                 </div>
 
@@ -308,7 +308,7 @@ const InputPanel: React.FC<InputPanelProps> = ({ config, onChange }) => {
                      />
                 </div>
 
-                {paymentData.network !== 'custom' && (
+                {paymentData.network !== CryptoNetwork.CUSTOM && (
                 <>
                     <div>
                         <label htmlFor="payment-amount" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Amount (Optional)</label>

--- a/src/components/InputPanel_PaymentInjection.test.tsx
+++ b/src/components/InputPanel_PaymentInjection.test.tsx
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { constructPaymentString } from '../utils/qrHelpers';
+import { CryptoNetwork } from '../types';
 
 describe('Payment String Construction - Injection Risks', () => {
   it('prevents parameter injection via label in Amount field', () => {
     // Attack vector: User inputs "1&label=Hacked" into amount field
     const data = {
-      network: 'bitcoin',
+      network: CryptoNetwork.BITCOIN,
       address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
       amount: '1&label=Hacked',
       label: 'Official Donation'
@@ -27,7 +28,7 @@ describe('Payment String Construction - Injection Risks', () => {
      // Attack vector: User inputs address "1A...?amount=100" and sets amount empty
      // Or user inputs address "1A...?label=Malicious"
      const data = {
-       network: 'bitcoin',
+       network: CryptoNetwork.BITCOIN,
        address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa?label=Evil',
        amount: '0.5',
        label: 'Good'

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,11 +165,22 @@ export interface SmsData {
 }
 
 /**
+ * Supported cryptocurrency networks for payment.
+ */
+export enum CryptoNetwork {
+  BITCOIN = 'bitcoin',
+  ETHEREUM = 'ethereum',
+  SOLANA = 'solana',
+  LITECOIN = 'litecoin',
+  CUSTOM = 'custom',
+}
+
+/**
  * Data structure for Payment information (Crypto).
  */
 export interface PaymentData {
   /** The cryptocurrency network (e.g. bitcoin, ethereum). */
-  network: string;
+  network: CryptoNetwork;
   /** The wallet address. */
   address: string;
   /** The amount to request (optional). */

--- a/src/utils/qrHelpers.test.ts
+++ b/src/utils/qrHelpers.test.ts
@@ -9,7 +9,7 @@ import {
   escapeWifiString,
   escapeVCardString
 } from './qrHelpers';
-import { WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption } from '../types';
+import { WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption, CryptoNetwork } from '../types';
 
 describe('QR Helpers', () => {
   describe('constructWifiString', () => {
@@ -192,7 +192,7 @@ describe('QR Helpers', () => {
   describe('constructPaymentString', () => {
     it('constructs a basic crypto URI', () => {
       const data: PaymentData = {
-        network: 'bitcoin',
+        network: CryptoNetwork.BITCOIN,
         address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
         amount: '',
         label: ''
@@ -202,7 +202,7 @@ describe('QR Helpers', () => {
 
     it('constructs a crypto URI with amount and label', () => {
       const data: PaymentData = {
-        network: 'ethereum',
+        network: CryptoNetwork.ETHEREUM,
         address: '0x123...',
         amount: '1.5',
         label: 'Payment for Services'
@@ -215,7 +215,7 @@ describe('QR Helpers', () => {
 
     it('sanitizes address input to prevent parameter injection', () => {
       const data: PaymentData = {
-        network: 'bitcoin',
+        network: CryptoNetwork.BITCOIN,
         address: '1A1...?amount=1000',
         amount: '0.1',
         label: ''
@@ -228,7 +228,7 @@ describe('QR Helpers', () => {
 
     it('encodes amount to prevent injection', () => {
         const data: PaymentData = {
-            network: 'bitcoin',
+            network: CryptoNetwork.BITCOIN,
             address: '1A1...',
             amount: '1&label=hacked',
             label: ''
@@ -240,7 +240,7 @@ describe('QR Helpers', () => {
 
     it('returns raw address for custom network', () => {
          const data: PaymentData = {
-            network: 'custom',
+            network: CryptoNetwork.CUSTOM,
             address: 'myprotocol://addr',
             amount: '10', // Should be ignored or handled by the user in the address field
             label: 'label'

--- a/src/utils/qrHelpers.ts
+++ b/src/utils/qrHelpers.ts
@@ -1,4 +1,4 @@
-import { WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption } from '../types';
+import { WifiData, EmailData, VCardData, PhoneData, SmsData, PaymentData, WifiEncryption, CryptoNetwork } from '../types';
 import { isDangerousUrl, cleanPhoneNumber, sanitizeInput } from './security';
 
 /**
@@ -98,7 +98,7 @@ export const constructSmsString = (data: SmsData): string => {
 export const constructPaymentString = (data: PaymentData): string => {
   let paymentString = '';
 
-  if (data.network === 'custom') {
+  if (data.network === CryptoNetwork.CUSTOM) {
     if (isDangerousUrl(data.address)) {
       return '';
     }

--- a/src/utils/qrHelpers_SadPaths.test.ts
+++ b/src/utils/qrHelpers_SadPaths.test.ts
@@ -5,7 +5,7 @@ import {
   constructVCardString,
   constructPaymentString
 } from './qrHelpers';
-import { EmailData, VCardData, PaymentData } from '../types';
+import { EmailData, VCardData, PaymentData, CryptoNetwork } from '../types';
 
 describe('QR Helpers Sad Paths', () => {
   describe('escapeVCardString', () => {
@@ -83,7 +83,7 @@ describe('QR Helpers Sad Paths', () => {
   describe('constructPaymentString', () => {
     it('should handle parameter injection attempts in amount', () => {
       const data: PaymentData = {
-        network: 'bitcoin',
+        network: CryptoNetwork.BITCOIN,
         address: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
         amount: '0.1&label=Hacked',
         label: 'Donation'

--- a/src/utils/qrHelpers_Security.test.ts
+++ b/src/utils/qrHelpers_Security.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { constructPaymentString } from './qrHelpers';
+import { CryptoNetwork } from '../types';
 
 describe('qrHelpers Security', () => {
   describe('constructPaymentString', () => {
     it('blocks dangerous schemes in custom network', () => {
       const dangerousPayload = 'javascript:alert(1)';
       const result = constructPaymentString({
-        network: 'custom',
+        network: CryptoNetwork.CUSTOM,
         address: dangerousPayload,
         amount: '',
         label: ''
@@ -17,7 +18,7 @@ describe('qrHelpers Security', () => {
     it('allows valid custom URIs', () => {
       const validPayload = 'bitcoin:123?amount=10';
       const result = constructPaymentString({
-        network: 'custom',
+        network: CryptoNetwork.CUSTOM,
         address: validPayload,
         amount: '',
         label: ''
@@ -30,7 +31,7 @@ describe('qrHelpers Security', () => {
       // but we ensure it doesn't start with javascript:
       const payload = 'bitcoin:123?amount=100&label=Hack';
       const result = constructPaymentString({
-        network: 'custom',
+        network: CryptoNetwork.CUSTOM,
         address: payload,
         amount: '',
         label: ''


### PR DESCRIPTION
💩 **Smell:** "Primitive Obsession" - Payment networks were handled as magic strings ('bitcoin', 'ethereum', etc.) scattered across `types.ts`, `InputPanel.tsx`, and `qrHelpers.ts`.
✨ **Polish:** Introduced a `CryptoNetwork` enum in `src/types.ts` and updated `PaymentData` to use it. Replaced all raw string occurrences with safe Enum references.
📉 **Reduction:** Cleaned up type definitions and improved type safety.
🛡️ **Safety:** Verified with full test suite (`npm test`). No logic changes, only structural improvements for type safety.

---
*PR created automatically by Jules for task [588844580563360540](https://jules.google.com/task/588844580563360540) started by @fderuiter*