### PR TITLE
Shield: Fix SMS/Phone URI injection vulnerability

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -19,3 +19,7 @@
 ## 2025-02-18 - Unsupported 3-digit Hex in Color Utils
 **Discovery:** `getContrastRatio` treated valid 3-digit hex codes (e.g., `#FFF`) as invalid inputs, returning 0 contrast. This caused false positive "Low Contrast" warnings in the UI when users manually entered short hex codes.
 **Defense:** Updated `getLuminance` to expand 3-digit hex codes to 6-digit equivalents and updated `getContrastRatio` to validate and accept length-4 hex strings.
+
+## 2025-02-18 - [URI Injection in SMS/Tel Schemas]
+**Discovery:** `cleanPhoneNumber` was too permissive, allowing URI control characters (`?`, `&`, `=`) to persist. This enabled parameter injection in `sms:` and `tel:` URIs (e.g., `sms:123?body=hacked` resulting in `sms:123?body=hacked?body=hello`).
+**Defense:** Updated `cleanPhoneNumber` regex to strictly strip `?`, `&`, and `=` characters, ensuring that user input in the number field cannot alter the URI structure or inject parameters.

--- a/src/utils/qrHelpers_SadPaths.test.ts
+++ b/src/utils/qrHelpers_SadPaths.test.ts
@@ -3,9 +3,10 @@ import {
   escapeVCardString,
   constructEmailString,
   constructVCardString,
-  constructPaymentString
+  constructPaymentString,
+  constructSmsString
 } from './qrHelpers';
-import { EmailData, VCardData, PaymentData, CryptoNetwork } from '../types';
+import { EmailData, VCardData, PaymentData, CryptoNetwork, SmsData } from '../types';
 
 describe('QR Helpers Sad Paths', () => {
   describe('escapeVCardString', () => {
@@ -91,6 +92,21 @@ describe('QR Helpers Sad Paths', () => {
       const result = constructPaymentString(data);
       // Should encode the ampersand
       expect(result).toContain('amount=0.1%26label%3DHacked');
+    });
+  });
+
+  describe('constructSmsString', () => {
+    it('should prevent parameter injection in SMS number', () => {
+      const data: SmsData = {
+        number: '123?body=injected',
+        message: 'hello'
+      };
+      // If we don't sanitize the number, we get sms:123?body=injected?body=hello
+      // We expect the number to be cleaned of URI control characters
+      const result = constructSmsString(data);
+      // It should NOT contain two 'body=' params or two '?'
+      expect(result).not.toMatch(/\?.*\?/);
+      expect(result).toBe('sms:123bodyinjected?body=hello');
     });
   });
 });

--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -62,6 +62,11 @@ describe('Security Utils', () => {
       it('removes spaces and colons', () => {
           expect(cleanPhoneNumber('123 456:789')).toBe('123456789');
       });
+
+      it('removes URI control characters', () => {
+          expect(cleanPhoneNumber('123?body=hacked')).toBe('123bodyhacked');
+          expect(cleanPhoneNumber('123&foo=bar')).toBe('123foobar');
+      });
   });
 
   describe('sanitizeInput', () => {

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -30,10 +30,10 @@ export const isDangerousUrl = (url: string | undefined): boolean => {
 };
 
 /**
- * Removes spaces and colons from a phone number string.
+ * Removes spaces, colons, and URI control characters from a phone number string.
  */
 export const cleanPhoneNumber = (number: string): string => {
-  return number.replace(/[\s:]+/g, '');
+  return number.replace(/[\s:?&=]+/g, '');
 };
 
 /**


### PR DESCRIPTION
Prevents URI injection in SMS and Phone QR codes by strictly sanitizing the phone number input to remove `?`, `&`, and `=` characters.

This change:
- Modifies `src/utils/security.ts` to update the regex in `cleanPhoneNumber`.
- Adds a new regression test in `src/utils/qrHelpers_SadPaths.test.ts`.
- Adds a new unit test in `src/utils/security.test.ts`.
- Updates `.jules/shield.md` with the finding.

---
*PR created automatically by Jules for task [12535056627053707944](https://jules.google.com/task/12535056627053707944) started by @fderuiter*