### PR TITLE
🔦 Beacon: Add Open Graph Image Dimensions

### DIFF
--- a/.jules/beacon.md
+++ b/.jules/beacon.md
@@ -15,3 +15,8 @@ Updated `Head.tsx` to use this new asset and upgraded the Twitter Card type to `
 ## 2025-02-14 - [Structured Data] High-Res Images for WebApplication Schema
 Switched from low-res `favicon.png` to high-res `og-image.png` in `WebApplication` schema to improve rich result appearance.
 Updated `src/pages/index/+Page.tsx` and `src/pages/wifi-qr-code/+Page.tsx` and their respective tests.
+
+## 2025-02-15 - [Social Signals] Open Graph Image Dimensions
+**Discovery:** Social platforms often delay rendering link previews or fallback to smaller cards if they cannot immediately determine the image dimensions.
+**Signal:** Added explicit `og:image:width`, `og:image:height`, and `og:image:type` meta tags to `src/layouts/Head.tsx`.
+**Impact:** Ensures immediate, full-size rendering of social cards on platforms like Facebook, LinkedIn, and Discord without requiring them to download the image first.

--- a/src/layouts/Head.test.tsx
+++ b/src/layouts/Head.test.tsx
@@ -35,4 +35,21 @@ describe('HeadDefault', () => {
     expect(content).toContain("font-src 'self' https://fonts.gstatic.com");
     expect(content).toContain("img-src 'self' data:");
   });
+
+  it('includes Open Graph image dimensions', () => {
+    const { container } = render(<HeadDefault />, { container: document.head });
+
+    const width = container.querySelector('meta[property="og:image:width"]');
+    const height = container.querySelector('meta[property="og:image:height"]');
+    const type = container.querySelector('meta[property="og:image:type"]');
+
+    expect(width).toBeInTheDocument();
+    expect(width?.getAttribute('content')).toBe('1280');
+
+    expect(height).toBeInTheDocument();
+    expect(height?.getAttribute('content')).toBe('720');
+
+    expect(type).toBeInTheDocument();
+    expect(type?.getAttribute('content')).toBe('image/png');
+  });
 });

--- a/src/layouts/Head.tsx
+++ b/src/layouts/Head.tsx
@@ -120,6 +120,9 @@ export default function HeadDefault() {
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:image" content={`${DOMAIN}/og-image.png`} />
+      <meta property="og:image:type" content="image/png" />
+      <meta property="og:image:width" content="1280" />
+      <meta property="og:image:height" content="720" />
       <meta property="og:image:alt" content="QRCraftly QR Code Example" />
 
       {/* Social Signals (Twitter) */}


### PR DESCRIPTION
🕵️ **Discovery:** Social platforms often delay rendering link previews or fallback to smaller cards if they cannot immediately determine the image dimensions.
🔦 **Signal:** Added explicit `og:image:width`, `og:image:height`, and `og:image:type` meta tags to `src/layouts/Head.tsx`.
📈 **Impact:** Ensures immediate, full-size rendering of social cards on platforms like Facebook, LinkedIn, and Discord.
🔬 **Verification:** `npm test src/layouts/Head.test.tsx` passes and verifies the presence of these tags.

---
*PR created automatically by Jules for task [4646584342738538915](https://jules.google.com/task/4646584342738538915) started by @fderuiter*