### PR TITLE
🛡️ Shield: Fix Email Header Injection Vulnerability

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -23,3 +23,7 @@
 ## 2025-02-18 - [URI Injection in SMS/Tel Schemas]
 **Discovery:** `cleanPhoneNumber` was too permissive, allowing URI control characters (`?`, `&`, `=`) to persist. This enabled parameter injection in `sms:` and `tel:` URIs (e.g., `sms:123?body=hacked` resulting in `sms:123?body=hacked?body=hello`).
 **Defense:** Updated `cleanPhoneNumber` regex to strictly strip `?`, `&`, and `=` characters, ensuring that user input in the number field cannot alter the URI structure or inject parameters.
+
+## 2025-02-18 - [Header Injection in Email Schemas]
+**Discovery:** `constructEmailString` did not sanitize newlines from email inputs, allowing attackers to inject arbitrary headers (e.g. `cc:`) into `mailto:` links via crafted input (e.g., `user@example.com\ncc:attacker`).
+**Defense:** Updated `sanitizeInput` in `src/utils/security.ts` to strictly strip all control characters (0x00-0x1F, 0x7F-0x9F), neutralizing newline injection attacks across email and other URI schemes.

--- a/src/utils/qrHelpers_EmailSecurity.test.ts
+++ b/src/utils/qrHelpers_EmailSecurity.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { constructEmailString } from './qrHelpers';
+import { EmailData } from '../types';
+
+describe('QR Helpers Email Security', () => {
+  it('constructEmailString should strip newlines from email to prevent header injection', () => {
+    const data: EmailData = {
+      email: 'user@example.com\ncc:attacker@example.com',
+      subject: 'Test',
+      body: 'Body'
+    };
+    const result = constructEmailString(data);
+    // The result should not contain \n or %0A (if encoded, but currently not encoded)
+    expect(result).not.toContain('\n');
+    expect(result).not.toContain('\r');
+    // If it's correctly stripped: mailto:user@example.comcc:attacker@example.com?subject=Test&body=Body
+    expect(result).toBe('mailto:user@example.comcc:attacker@example.com?subject=Test&body=Body');
+  });
+
+  it('constructEmailString should strip control characters from email', () => {
+      const data: EmailData = {
+          email: 'user@example.com\x00',
+          subject: 'Test',
+          body: 'Body'
+      };
+      const result = constructEmailString(data);
+      expect(result).not.toContain('\x00');
+      expect(result).toBe('mailto:user@example.com?subject=Test&body=Body');
+  });
+});

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -38,9 +38,11 @@ export const cleanPhoneNumber = (number: string): string => {
 };
 
 /**
- * Sanitizes input by stripping query parameters.
- * Useful for preventing parameter injection in constructed URIs.
+ * Sanitizes input by stripping query parameters and control characters.
+ * Useful for preventing parameter injection in constructed URIs and header injection.
  */
 export const sanitizeInput = (str: string): string => {
-  return str.split('?')[0];
+  // Remove control characters (00-1F, 7F-9F) to prevent header injection
+  const noControl = str.replace(/[\x00-\x1F\x7F-\x9F]+/g, '');
+  return noControl.split('?')[0];
 };


### PR DESCRIPTION
🛑 **Vulnerability:** `constructEmailString` allowed control characters (like `\n`) in the email address field, enabling Header Injection in `mailto:` URIs (e.g., `user@example.com\nCC:attacker`).

🛡️ **Defense:** Updated `sanitizeInput` in `src/utils/security.ts` to strictly strip all control characters (ASCII 0x00-0x1F, 0x7F-0x9F) from the input. This neutralizes the attack by merging the injected header into the address, rendering it harmless.

🔬 **Verification:** Added `src/utils/qrHelpers_EmailSecurity.test.ts` which asserts that inputs with newlines are sanitized correctly. Run via `npm test src/utils/qrHelpers_EmailSecurity.test.ts`.

📊 **Impact:** Prevents potential phishing or spam attacks via manipulated QR codes.

---
*PR created automatically by Jules for task [12832774755818965589](https://jules.google.com/task/12832774755818965589) started by @fderuiter*