### PR TITLE
⚡ Bolt: Batch canvas drawing for complex styles

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - [Canvas Optimization]
 **Learning:** Batching canvas path operations (e.g., `ctx.rect`) and filling once is significantly faster than immediate drawing (`ctx.fillRect`) for complex, repetitive shapes like QR code modules.
 **Action:** When optimizing canvas rendering, consolidate individual draw calls into single paths where possible, but ensure to update tests that spy on specific draw methods (e.g., `fillRect` vs `rect`).
+
+## 2024-05-23 - [Complex Shape Batching]
+**Learning:** Even complex shapes constructed with `ctx.save()`/`ctx.restore()` and transformations (like `GRUNGE` style rectangles) or multiple line segments (like `STARBURST`) can be batched by appending them to a single path instead of drawing immediately. This reduces draw calls from O(n) to O(1) for the rasterization step.
+**Action:** Extend helper functions to accept an `addToPath` parameter that skips `beginPath` and `fill`, allowing the caller to manage the path lifecycle.

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -681,7 +680,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -725,7 +723,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2483,7 +2480,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2580,7 +2578,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2973,7 +2970,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3065,7 +3061,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^7.0.0",
         "prebuild-install": "^7.1.3"
@@ -3320,7 +3315,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.266",
@@ -3804,7 +3800,6 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -4168,6 +4163,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4552,7 +4548,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4602,6 +4597,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4617,6 +4613,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4683,7 +4680,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4693,7 +4689,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4706,7 +4701,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4723,7 +4719,6 @@
       "resolved": "https://registry.npmjs.org/react-streaming/-/react-streaming-0.4.13.tgz",
       "integrity": "sha512-LNwxjglFKYDHxkt2N0rLPzqJiR/mWec94VVdi683t/Ha2VXxB8BXxni+TKdWt12v6fM1ygNgJYtzQrxFaTBFgw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@brillout/import": "^0.2.3",
         "@brillout/json-serializer": "^0.5.1",
@@ -5368,7 +5363,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -5485,7 +5479,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5561,7 +5554,6 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -5739,7 +5731,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/src/components/QRCanvas.tsx
+++ b/src/components/QRCanvas.tsx
@@ -385,7 +385,10 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
         ctx.fillStyle = config.fgColor;
 
         // Optimization: Batch drawing for compatible styles to reduce draw calls
-        const isBatchable = [QRStyle.STANDARD, QRStyle.MODERN, QRStyle.SWISS, QRStyle.FLUID, QRStyle.CIRCUIT].includes(config.style);
+        const isBatchable = [
+            QRStyle.STANDARD, QRStyle.MODERN, QRStyle.SWISS, QRStyle.FLUID, QRStyle.CIRCUIT,
+            QRStyle.HIVE, QRStyle.GRUNGE, QRStyle.STARBURST
+        ].includes(config.style);
 
         if (isBatchable) {
             ctx.beginPath();
@@ -434,26 +437,23 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
                              if (hasTop) ctx.rect(cx - thickness/2, y, thickness, cellSize/2 + 1);
                            }
                            break;
+                       case QRStyle.HIVE:
+                           // Massive Hexagon
+                           drawPoly(ctx, cx, cy, cellSize/1.55, 6, 0, true, true);
+                           break;
+                       case QRStyle.GRUNGE:
+                           // Full size rough rect, minimal jitter
+                           drawRoughRect(ctx, x, y, cellSize, cellSize, true);
+                           break;
+                       case QRStyle.STARBURST:
+                           // Fat star - nearly a square
+                           drawStar(ctx, cx, cy, cellSize/1.5, cellSize/2.2, 5, true, true);
+                           break;
                        case QRStyle.STANDARD:
                        default:
                            ctx.rect(Math.floor(x), Math.floor(y), Math.ceil(cellSize), Math.ceil(cellSize));
                            break;
                    }
-              } else {
-                  switch(config.style) {
-                      case QRStyle.HIVE:
-                        // Massive Hexagon
-                        drawPoly(ctx, cx, cy, cellSize/1.55, 6, 0, true);
-                        break;
-                      case QRStyle.GRUNGE:
-                        // Full size rough rect, minimal jitter
-                        drawRoughRect(ctx, x, y, cellSize, cellSize);
-                        break;
-                      case QRStyle.STARBURST:
-                         // Fat star - nearly a square
-                        drawStar(ctx, cx, cy, cellSize/1.5, cellSize/2.2, 5, true);
-                        break;
-                  }
               }
             }
           }

--- a/src/components/QRCanvas_Batching.test.tsx
+++ b/src/components/QRCanvas_Batching.test.tsx
@@ -1,0 +1,153 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach, Mock } from 'vitest';
+import QRCanvas from './QRCanvas';
+import { DEFAULT_CONFIG } from '../constants';
+import { QRStyle } from '../types';
+import QRCode from 'qrcode';
+
+// Mock qrcode module
+vi.mock('qrcode', () => {
+  const createMock = vi.fn();
+  return {
+    create: createMock,
+    default: {
+      create: createMock,
+    },
+  };
+});
+
+// Mock Image
+const originalImage = window.Image;
+
+describe('QRCanvas Batch Rendering', () => {
+  let mockContext: any;
+  let mockModules: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockContext = {
+      clearRect: vi.fn(),
+      fillRect: vi.fn(),
+      roundRect: vi.fn(),
+      beginPath: vi.fn(),
+      fill: vi.fn(),
+      arc: vi.fn(),
+      rect: vi.fn(),
+      save: vi.fn(),
+      translate: vi.fn(),
+      rotate: vi.fn(),
+      restore: vi.fn(),
+      scale: vi.fn(),
+      drawImage: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      quadraticCurveTo: vi.fn(),
+      setLineDash: vi.fn(),
+      strokeRect: vi.fn(),
+      stroke: vi.fn(),
+      fillText: vi.fn(),
+      canvas: { width: 0, height: 0 },
+      fillStyle: '',
+      strokeStyle: '',
+      lineWidth: 0,
+    };
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => mockContext);
+
+    // 21x21 modules
+    mockModules = {
+      size: 21,
+      get: vi.fn().mockReturnValue(false),
+    };
+
+    (QRCode.create as unknown as Mock).mockReturnValue({
+      modules: mockModules,
+    });
+
+    window.Image = class {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      src = '';
+      complete = false;
+      crossOrigin = '';
+    } as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.Image = originalImage;
+  });
+
+  const setModulesPattern = () => {
+      // Set a few modules to true to trigger drawing
+      mockModules.get.mockImplementation((r: number, c: number) => {
+          // Activate a block of modules (6x6 = 36 modules)
+          // Avoid eyes (0-7, 0-7 etc)
+          if (r > 8 && r < 15 && c > 8 && c < 15) return true;
+          return false;
+      });
+  };
+
+  it('batches HIVE style (drawPoly) calls', async () => {
+      setModulesPattern();
+      const config = { ...DEFAULT_CONFIG, style: QRStyle.HIVE };
+      render(<QRCanvas config={config} />);
+
+      // Wait for drawing to happen
+      await waitFor(() => {
+          expect(mockContext.fill).toHaveBeenCalled();
+      });
+
+      const fillCallCount = mockContext.fill.mock.calls.length;
+
+      // With optimization: fill should be called once for background + once for modules batch + 3 eyes = ~5
+      // Without optimization: fill called for every module (36) + eyes + background = >40
+      expect(fillCallCount).toBeLessThan(10);
+  });
+
+  it('batches STARBURST style (drawStar) calls', async () => {
+      setModulesPattern();
+      const config = { ...DEFAULT_CONFIG, style: QRStyle.STARBURST };
+      render(<QRCanvas config={config} />);
+
+      await waitFor(() => {
+          expect(mockContext.fill).toHaveBeenCalled();
+      });
+
+      const fillCallCount = mockContext.fill.mock.calls.length;
+      expect(fillCallCount).toBeLessThan(10);
+  });
+
+  it('batches GRUNGE style (drawRoughRect) calls', async () => {
+      setModulesPattern();
+      const config = { ...DEFAULT_CONFIG, style: QRStyle.GRUNGE };
+      render(<QRCanvas config={config} />);
+
+      await waitFor(() => {
+        // Wait for rendering to start.
+        // In unoptimized mode, fillRect is called.
+        // In optimized mode, fill is called.
+        // So we wait for clearRect which means render cycle started,
+        // but we need to wait for actual drawing commands.
+        // Let's wait for fillRect (background uses it)
+        expect(mockContext.fillRect).toHaveBeenCalled();
+      });
+
+      // Allow some time for module loop to finish if it's async/heavy?
+      // No, it's synchronous inside useEffect.
+
+      const fillRectCount = mockContext.fillRect.mock.calls.length;
+
+      // With optimization: fillRect only used for eyes (frames + holes) + background = ~4-10
+      // Modules use rect().
+      // Without optimization: fillRect called for every module (36) + eyes + background = >40
+      expect(fillRectCount).toBeLessThan(20);
+
+      // And we expect fill() to be called for the modules batch (if optimized)
+      // If unoptimized, fill() is NOT called for modules (only background if border enabled? No default border is disabled).
+      // Wait, background uses fillRect.
+      expect(mockContext.fill).toHaveBeenCalled();
+  });
+});

--- a/src/utils/canvasHelpers.test.ts
+++ b/src/utils/canvasHelpers.test.ts
@@ -20,6 +20,7 @@ describe('canvasHelpers', () => {
       translate: vi.fn(),
       rotate: vi.fn(),
       fillRect: vi.fn(),
+      rect: vi.fn(),
     } as unknown as CanvasRenderingContext2D;
   });
 
@@ -66,6 +67,14 @@ describe('canvasHelpers', () => {
       expect(ctx.fill).not.toHaveBeenCalled();
       expect(ctx.stroke).toHaveBeenCalled();
     });
+
+    it('should add to path without beginPath/fill if addToPath is true', () => {
+      drawPoly(ctx, 50, 50, 20, 6, 0, true, true);
+      expect(ctx.beginPath).not.toHaveBeenCalled();
+      expect(ctx.fill).not.toHaveBeenCalled();
+      expect(ctx.moveTo).toHaveBeenCalled();
+      expect(ctx.closePath).toHaveBeenCalled();
+    });
   });
 
   describe('drawStar', () => {
@@ -88,6 +97,14 @@ describe('canvasHelpers', () => {
       expect(ctx.fill).not.toHaveBeenCalled();
       expect(ctx.stroke).toHaveBeenCalled();
     });
+
+    it('should add to path without beginPath/fill if addToPath is true', () => {
+      drawStar(ctx, 50, 50, 20, 10, 5, true, true);
+      expect(ctx.beginPath).not.toHaveBeenCalled();
+      expect(ctx.fill).not.toHaveBeenCalled();
+      expect(ctx.moveTo).toHaveBeenCalled();
+      expect(ctx.closePath).toHaveBeenCalled();
+    });
   });
 
   describe('drawRoughRect', () => {
@@ -99,6 +116,13 @@ describe('canvasHelpers', () => {
       expect(ctx.rotate).toHaveBeenCalledWith(0.02);
       expect(ctx.fillRect).toHaveBeenCalledWith(-50, -25, 100, 50); // -w/2, -h/2
       expect(ctx.restore).toHaveBeenCalled();
+    });
+
+    it('should use rect instead of fillRect if addToPath is true', () => {
+      drawRoughRect(ctx, 10, 10, 100, 50, true);
+
+      expect(ctx.fillRect).not.toHaveBeenCalled();
+      expect(ctx.rect).toHaveBeenCalledWith(-50, -25, 100, 50);
     });
   });
 

--- a/src/utils/canvasHelpers.ts
+++ b/src/utils/canvasHelpers.ts
@@ -36,9 +36,10 @@ export const drawRoundRect = (ctx: CanvasRenderingContext2D, x: number, y: numbe
  * @param sides The number of sides.
  * @param rotate Rotation angle in radians (default: 0).
  * @param fill Whether to fill the polygon (default: true).
+ * @param addToPath Whether to add to the current path without starting a new one or filling (default: false).
  */
-export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r: number, sides: number, rotate: number = 0, fill: boolean = true) => {
-  ctx.beginPath();
+export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r: number, sides: number, rotate: number = 0, fill: boolean = true, addToPath: boolean = false) => {
+  if (!addToPath) ctx.beginPath();
   for (let i = 0; i < sides; i++) {
     const theta = rotate + (i * 2 * Math.PI / sides);
     const px = x + r * Math.cos(theta);
@@ -47,7 +48,9 @@ export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r:
     else ctx.lineTo(px, py);
   }
   ctx.closePath();
-  if (fill) ctx.fill(); else ctx.stroke();
+  if (!addToPath) {
+    if (fill) ctx.fill(); else ctx.stroke();
+  }
 };
 
 /**
@@ -59,14 +62,15 @@ export const drawPoly = (ctx: CanvasRenderingContext2D, x: number, y: number, r:
  * @param innerR The inner radius.
  * @param spikes The number of spikes.
  * @param fill Whether to fill the star (default: true).
+ * @param addToPath Whether to add to the current path without starting a new one or filling (default: false).
  */
-export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, outerR: number, innerR: number, spikes: number, fill: boolean = true) => {
+export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, outerR: number, innerR: number, spikes: number, fill: boolean = true, addToPath: boolean = false) => {
   let rot = Math.PI / 2 * 3;
   let x = cx;
   let y = cy;
   const step = Math.PI / spikes;
 
-  ctx.beginPath();
+  if (!addToPath) ctx.beginPath();
   ctx.moveTo(cx, cy - outerR);
   for (let i = 0; i < spikes; i++) {
     x = cx + Math.cos(rot) * outerR;
@@ -81,7 +85,9 @@ export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, 
   }
   ctx.lineTo(cx, cy - outerR);
   ctx.closePath();
-  if (fill) ctx.fill(); else ctx.stroke();
+  if (!addToPath) {
+    if (fill) ctx.fill(); else ctx.stroke();
+  }
 };
 
 /**
@@ -91,13 +97,18 @@ export const drawStar = (ctx: CanvasRenderingContext2D, cx: number, cy: number, 
  * @param y The top-left y coordinate.
  * @param w The width.
  * @param h The height.
+ * @param addToPath Whether to add to the current path instead of filling immediately (default: false).
  */
-export const drawRoughRect = (ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number) => {
+export const drawRoughRect = (ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, addToPath: boolean = false) => {
   ctx.save();
   // Just a slight rotation for style
   ctx.translate(x + w / 2, y + h / 2);
   ctx.rotate(0.02);
-  ctx.fillRect(-w / 2, -h / 2, w, h);
+  if (addToPath) {
+    ctx.rect(-w / 2, -h / 2, w, h);
+  } else {
+    ctx.fillRect(-w / 2, -h / 2, w, h);
+  }
   ctx.restore();
 };
 


### PR DESCRIPTION
💡 What: Optimized `HIVE`, `GRUNGE`, and `STARBURST` QR code styles by batching canvas operations.
🎯 Why: Previously, these styles issued individual `fill()` or `fillRect()` calls for each module, causing significant overhead (e.g. ~40 calls for a small code, hundreds for larger ones). This optimization batches them into a single path and fills once.
📊 Impact: Reduces rasterization overhead. `fill` calls reduced to ~4-7 per frame regardless of QR code complexity.
🔬 Measurement: Verified with `src/components/QRCanvas_Batching.test.tsx` which asserts that `ctx.fill` / `ctx.fillRect` call counts are minimal (<10) instead of proportional to module count.


---
*PR created automatically by Jules for task [1750075654886351944](https://jules.google.com/task/1750075654886351944) started by @fderuiter*