### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unicode bypass in URL validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The deprecated `smsto:` scheme was used without encoding the message body, allowing injection of delimiters (like `:`) to potentially alter the target number or break the URI.
 **Learning:** `smsto:` does not have a standard way to encode bodies. The standard `sms:` scheme supports `?body=` with URL-encoded values.
 **Prevention:** Use standard URI schemes (RFC 5724 for SMS) and always `encodeURIComponent` user-supplied data in URI parameters.
+
+## 2026-02-08 - Unicode Bypass in URL Validation
+**Vulnerability:** `isDangerousUrl` stripped ASCII control characters but failed to handle Unicode zero-width characters (e.g., `\u200B`), allowing `jav\u200Bascript:` to bypass the check while potentially executing in browsers.
+**Learning:** Standard regex character classes like `\s` or ranges `\x00-\x1F` are insufficient for security sanitization in a global context. Unicode Property Escapes (`\p{C}`, `\p{Z}`) are essential for robustly matching invisible characters.
+**Prevention:** Use `const CONTROL_CHARS_REGEX = /[\p{C}\p{Z}]+/gu;` to strip all control, format, and separator characters when normalizing strings for security checks.

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -8,7 +8,17 @@ export const safeJsonLdStringify = (data: any): string => {
                              .replace(/&/g, '\\u0026');
 };
 
-const CONTROL_CHARS_REGEX = /[\x00-\x1F\x7F-\x9F\s]+/g;
+/**
+ * Regex to match all control characters (\p{C}) and separators (\p{Z}).
+ * Includes:
+ * - \p{Cc}: Control (e.g., \x00-\x1F, \x7F-\x9F)
+ * - \p{Cf}: Format (e.g., Zero Width Space \u200B, Joiners \u200C/D)
+ * - \p{Co}: Private Use
+ * - \p{Cs}: Surrogate
+ * - \p{Cn}: Unassigned
+ * - \p{Z}: Separators (Space, Line Sep, Para Sep)
+ */
+const CONTROL_CHARS_REGEX = /[\p{C}\p{Z}]+/gu;
 
 const DANGEROUS_PROTOCOLS = [
   'javascript:',
@@ -24,7 +34,7 @@ const DANGEROUS_PROTOCOLS = [
  */
 export const isDangerousUrl = (url: string | undefined): boolean => {
   if (!url) return false;
-  // Remove control characters (00-1F, 7F-9F) and whitespace globally
+  // Remove all control characters, invisible formatting, and whitespace globally
   const normalized = url.replace(CONTROL_CHARS_REGEX, '').toLowerCase();
 
   return DANGEROUS_PROTOCOLS.some(p => normalized.startsWith(p));

--- a/src/utils/security_unicode.test.ts
+++ b/src/utils/security_unicode.test.ts
@@ -1,0 +1,28 @@
+
+import { describe, it, expect } from 'vitest';
+import { isDangerousUrl } from './security';
+
+describe('isDangerousUrl Security Bypasses', () => {
+  it('should detect javascript protocol with zero width space', () => {
+    // \u200B is Zero Width Space
+    const dangerous = 'jav\u200Bascript:alert(1)';
+    expect(isDangerousUrl(dangerous)).toBe(true);
+  });
+
+  it('should detect javascript protocol with zero width non-joiner', () => {
+    // \u200C is Zero Width Non-Joiner
+    const dangerous = 'jav\u200Cascript:alert(1)';
+    expect(isDangerousUrl(dangerous)).toBe(true);
+  });
+
+  it('should detect javascript protocol with zero width joiner', () => {
+    // \u200D is Zero Width Joiner
+    const dangerous = 'jav\u200Dascript:alert(1)';
+    expect(isDangerousUrl(dangerous)).toBe(true);
+  });
+
+  it('should detect javascript protocol with mixed case and control chars', () => {
+    const dangerous = 'J\u0000a\u0001v\u0002a\u0003s\u0004c\u0005r\u0006i\u0007p\u0008t:alert(1)';
+    expect(isDangerousUrl(dangerous)).toBe(true);
+  });
+});


### PR DESCRIPTION
Updated `isDangerousUrl` to use Unicode Property Escapes (`/[\p{C}\p{Z}]+/gu`) to robustly strip all control and separator characters (including zero-width spaces like `\u200B`) before validating protocols. This prevents bypasses such as `jav\u200Bascript:`.

Added comprehensive tests in `src/utils/security_unicode.test.ts`.
Updated Sentinel's journal in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17907249069491554789](https://jules.google.com/task/17907249069491554789) started by @fderuiter*