### PR TITLE
🎨 Palette: Add value feedback to style sliders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -152,7 +152,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -681,7 +680,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -725,7 +723,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2483,7 +2480,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2580,7 +2578,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2973,7 +2970,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3065,7 +3061,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-addon-api": "^7.0.0",
         "prebuild-install": "^7.1.3"
@@ -3320,7 +3315,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.266",
@@ -3804,7 +3800,6 @@
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -4168,6 +4163,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4552,7 +4548,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4602,6 +4597,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4617,6 +4613,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4683,7 +4680,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4693,7 +4689,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4706,7 +4701,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -4723,7 +4719,6 @@
       "resolved": "https://registry.npmjs.org/react-streaming/-/react-streaming-0.4.13.tgz",
       "integrity": "sha512-LNwxjglFKYDHxkt2N0rLPzqJiR/mWec94VVdi683t/Ha2VXxB8BXxni+TKdWt12v6fM1ygNgJYtzQrxFaTBFgw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@brillout/import": "^0.2.3",
         "@brillout/json-serializer": "^0.5.1",
@@ -5368,7 +5363,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -5485,7 +5479,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5561,7 +5554,6 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -5739,7 +5731,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/src/components/StyleControls.tsx
+++ b/src/components/StyleControls.tsx
@@ -54,6 +54,49 @@ const ColorInput: React.FC<ColorInputProps> = ({
   </div>
 );
 
+interface RangeInputProps {
+  id: string;
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+  formatValue?: (value: number) => string;
+}
+
+const RangeInput: React.FC<RangeInputProps> = ({
+  id,
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+  formatValue = (v) => v.toString(),
+}) => (
+  <div>
+    <div className="flex justify-between mb-1">
+        <label htmlFor={id} className="block text-xs font-medium text-slate-500 dark:text-slate-400">
+            {label}
+        </label>
+        <span className="text-xs font-mono text-slate-600 dark:text-slate-300">
+            {formatValue(value)}
+        </span>
+    </div>
+    <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-full accent-teal-700 dark:accent-teal-500 cursor-pointer"
+    />
+  </div>
+);
+
 /**
  * A component providing UI controls for styling the QR code.
  * Allows users to change patterns, colors, and upload logos.
@@ -154,18 +197,15 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
                         </select>
                     </div>
                      <div>
-                        <label htmlFor="border-size" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">
-                            Width
-                        </label>
-                        <input
+                        <RangeInput
                             id="border-size"
-                            type="range"
-                            min="0.01"
-                            max="0.15"
-                            step="0.005"
+                            label="Width"
                             value={config.borderSize}
-                            onChange={(e) => onChange({ borderSize: parseFloat(e.target.value) })}
-                            className="w-full accent-teal-700 dark:accent-teal-500"
+                            min={0.01}
+                            max={0.15}
+                            step={0.005}
+                            onChange={(val) => onChange({ borderSize: val })}
+                            formatValue={(v) => `${Math.round(v * 100)}%`}
                         />
                     </div>
                 </div>
@@ -454,16 +494,15 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
                 {config.logoPaddingStyle !== 'none' && (
                   <div className="grid grid-cols-2 gap-4">
                       <div>
-                          <label htmlFor="logo-padding" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Padding</label>
-                           <input 
+                           <RangeInput
                               id="logo-padding"
-                              type="range" 
-                              min="0" 
-                              max="4" 
-                              step="0.5"
+                              label="Padding"
                               value={config.logoPadding}
-                              onChange={(e) => onChange({ logoPadding: parseFloat(e.target.value) })}
-                              className="w-full accent-teal-700 dark:accent-teal-500"
+                              min={0}
+                              max={4}
+                              step={0.5}
+                              onChange={(val) => onChange({ logoPadding: val })}
+                              formatValue={(v) => v.toFixed(1)}
                            />
                       </div>
                       <ColorInput
@@ -478,16 +517,15 @@ const StyleControls: React.FC<StyleControlsProps> = ({ config, onChange }) => {
                 )}
 
                 <div>
-                     <label htmlFor="logo-size" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Logo Size</label>
-                     <input 
+                     <RangeInput
                         id="logo-size"
-                        type="range" 
-                        min="0.1" 
-                        max="0.35" 
-                        step="0.01"
+                        label="Logo Size"
                         value={config.logoSize}
-                        onChange={(e) => onChange({ logoSize: parseFloat(e.target.value) })}
-                        className="w-full accent-teal-700 dark:accent-teal-500"
+                        min={0.1}
+                        max={0.35}
+                        step={0.01}
+                        onChange={(val) => onChange({ logoSize: val })}
+                        formatValue={(v) => `${Math.round(v * 100)}%`}
                      />
                 </div>
             </div>


### PR DESCRIPTION
**💡 What:**
Added a `RangeInput` component to `StyleControls.tsx` that displays the current numeric value next to the slider label. Applied this to the Border Width, Logo Padding, and Logo Size sliders.

**🎯 Why:**
Users previously had to guess the values for these settings (e.g., "is this 5% or 10%?"). Displaying the exact value (formatted as percentage or number) provides precision and improves the customization experience.

**📸 Before/After:**
Previously, sliders were just `input[type="range"]` elements. Now, they show:
- Width: `5%`
- Padding: `2.5`
- Logo Size: `25%`

**♿ Accessibility:**
The `label` is correctly associated with the `input` via `htmlFor`. The values are rendered in `span` elements adjacent to the label for context.

**Verification:**
- Validated with `npm test src/components/StyleControls.test.tsx` (all passed).
- Visually verified using Playwright screenshot (confirmed labels appear correctly).
- Validated type safety with `npm run lint`.

---
*PR created automatically by Jules for task [16272057902622740973](https://jules.google.com/task/16272057902622740973) started by @fderuiter*