### PR TITLE
🔦 Beacon: Add internal link to fix orphan WiFi page

### DIFF
--- a/src/pages/about/+Page.tsx
+++ b/src/pages/about/+Page.tsx
@@ -1,5 +1,5 @@
 
-import { Github, Shield, Database, Code, ArrowLeft, Zap } from 'lucide-react';
+import { Github, Shield, Database, Code, ArrowLeft, Zap, Wifi } from 'lucide-react';
 import { safeJsonLdStringify } from '@/utils/security';
 
 /**
@@ -129,6 +129,20 @@ export default function Page() {
             Our code is open for inspection and contribution. We believe in transparency.
           </p>
         </div>
+      </div>
+
+      <div className="mb-16 text-center">
+        <h2 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Specialized Generators</h2>
+        <p className="text-lg text-slate-600 dark:text-slate-300 max-w-2xl mx-auto mb-6">
+          Looking for a specific use case? Try our dedicated tools.
+        </p>
+        <a
+          href="/wifi-qr-code"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-teal-700 text-white rounded-xl font-medium hover:bg-teal-800 transition-colors shadow-lg shadow-teal-900/20"
+        >
+          <Wifi className="w-5 h-5" />
+          Create WiFi QR Code
+        </a>
       </div>
 
       <div className="bg-slate-50 dark:bg-slate-800/50 rounded-2xl p-8 border border-slate-200 dark:border-slate-700 text-center">

--- a/src/pages/about/Page.test.tsx
+++ b/src/pages/about/Page.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Page from './+Page';
+
+describe('About Page', () => {
+  it('renders the About page content', () => {
+    render(<Page />);
+
+    // Check main heading
+    expect(screen.getByRole('heading', { name: /About QRCraftly/i })).toBeInTheDocument();
+
+    // Check existing content
+    expect(screen.getByText(/Privacy-focused QR code generator/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Free & No Login/i })).toBeInTheDocument();
+  });
+
+  it('contains a link to the WiFi QR Code generator for better SEO discovery', () => {
+    render(<Page />);
+
+    // Check for the new section heading
+    expect(screen.getByRole('heading', { name: /Specialized Generators/i })).toBeInTheDocument();
+
+    // Check for the descriptive text
+    expect(screen.getByText(/Looking for a specific use case/i)).toBeInTheDocument();
+
+    // Check for the internal link
+    const wifiLink = screen.getByRole('link', { name: /Create WiFi QR Code/i });
+    expect(wifiLink).toBeInTheDocument();
+    expect(wifiLink).toHaveAttribute('href', '/wifi-qr-code');
+  });
+});


### PR DESCRIPTION
🕵️ **Discovery:** The `/wifi-qr-code` page was an "Orphan Page" - it existed and was in the sitemap, but had no internal links pointing to it from the main navigation or content pages. This makes it difficult for search engine crawlers to discover and assign authority to it, and for users to find it naturally.

🔦 **Signal:** I added a clear, semantic internal link to the `/wifi-qr-code` page within the content of the `About` page, under a new "Specialized Generators" section.

📈 **Impact:**
- **Improved Crawlability:** Search engines can now follow a direct link to index the WiFi QR code generator.
- **Better Site Structure:** The internal link signals the relationship between the main site and its specialized tools.
- **Enhanced User Discovery:** Users reading about the project can easily find the specific tool they might be looking for.

🔬 **Verification:**
- **Automated Test:** Added `src/pages/about/Page.test.tsx` which verifies the presence of the "Specialized Generators" heading and the correct `href` attribute on the link.
- **Frontend Verification:** Visually confirmed the new section's appearance and responsiveness using a Playwright script (screenshot verified).


---
*PR created automatically by Jules for task [1724770753572540222](https://jules.google.com/task/1724770753572540222) started by @fderuiter*