### PR TITLE
🛡️ Shield: Fix broken WiFi QR format on newlines

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -23,3 +23,7 @@
 ## 2025-02-18 - [URI Injection in SMS/Tel Schemas]
 **Discovery:** `cleanPhoneNumber` was too permissive, allowing URI control characters (`?`, `&`, `=`) to persist. This enabled parameter injection in `sms:` and `tel:` URIs (e.g., `sms:123?body=hacked` resulting in `sms:123?body=hacked?body=hello`).
 **Defense:** Updated `cleanPhoneNumber` regex to strictly strip `?`, `&`, and `=` characters, ensuring that user input in the number field cannot alter the URI structure or inject parameters.
+
+## 2025-02-18 - [Broken WiFi QR Format on Newlines]
+**Discovery:** `escapeWifiString` did not handle newline characters, causing `constructWifiString` to output multi-line strings when a password contained a newline (e.g., via copy-paste). This breaks the expected single-line format of the WiFi configuration string.
+**Defense:** Updated `escapeWifiString` to escape newlines as `\n` (literal backslash-n), ensuring the generated string remains valid and on a single line, consistent with `escapeVCardString`.

--- a/src/utils/qrHelpers.ts
+++ b/src/utils/qrHelpers.ts
@@ -7,7 +7,10 @@ import { isDangerousUrl, cleanPhoneNumber, sanitizeInput } from './security';
  */
 export const escapeWifiString = (str: string | undefined): string => {
   if (!str) return '';
-  return str.replace(/([\\;,":])/g, '\\$1');
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/\r\n|\r|\n/g, '\\n')
+    .replace(/([;,":])/g, '\\$1');
 };
 
 /**

--- a/src/utils/qrHelpers_SadPaths.test.ts
+++ b/src/utils/qrHelpers_SadPaths.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   escapeVCardString,
+  escapeWifiString,
   constructEmailString,
   constructVCardString,
   constructPaymentString,
@@ -26,6 +27,22 @@ describe('QR Helpers Sad Paths', () => {
       const input = 'Win\r\nMac\rUnix\n';
       const result = escapeVCardString(input);
       expect(result).toBe('Win\\nMac\\nUnix\\n');
+    });
+  });
+
+  describe('escapeWifiString', () => {
+    it('should escape newlines as \\n', () => {
+      const input = 'pass\nword';
+      const result = escapeWifiString(input);
+      expect(result).toBe('pass\\nword');
+    });
+
+    it('should escape newlines and other special chars correctly', () => {
+      const input = 'a;b\nc';
+      const result = escapeWifiString(input);
+      // ; -> \;
+      // \n -> \n
+      expect(result).toBe('a\\;b\\nc');
     });
   });
 


### PR DESCRIPTION
🛡️ **Vulnerability:** WiFi configuration strings for QR codes follow a specific format (e.g., `WIFI:S:ssid;P:password;;`). If a password contained a newline character (common in copy-paste scenarios), it would break the single-line structure of the string, causing QR readers to fail or misinterpret the data.
🛡️ **Defense:** Modified `escapeWifiString` to explicitly replace newline characters (`\n`, `\r`, `\r\n`) with the literal sequence `\n`. This ensures the string remains valid and on a single line. The implementation uses a chained replacement strategy to safely handle backslashes first, avoiding double-escaping issues.
🔬 **Verification:** Added a new test case in `src/utils/qrHelpers_SadPaths.test.ts` that specifically checks `pass\nword` is transformed into `pass\nword` (literal backslash-n), and that other special characters are still handled correctly.
📊 **Impact:** Prevents malformed QR codes for users with complex or pasted passwords, improving the reliability of the WiFi QR generator.

---
*PR created automatically by Jules for task [9300920101862692860](https://jules.google.com/task/9300920101862692860) started by @fderuiter*