### PR TITLE
🛡️ Sentinel: Fix Invisible Character URL Filter Bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The deprecated `smsto:` scheme was used without encoding the message body, allowing injection of delimiters (like `:`) to potentially alter the target number or break the URI.
 **Learning:** `smsto:` does not have a standard way to encode bodies. The standard `sms:` scheme supports `?body=` with URL-encoded values.
 **Prevention:** Use standard URI schemes (RFC 5724 for SMS) and always `encodeURIComponent` user-supplied data in URI parameters.
+
+## 2026-02-07 - Invisible Character Filter Bypass
+**Vulnerability:** Input validation filters using standard regex whitespace (`\s`) can be bypassed using invisible Unicode characters like Zero Width Space (`\u200B`), which are ignored by some URL parsers but not matched by `\s`.
+**Learning:** `\s` in JavaScript RegExp does not include all invisible Unicode characters. Attackers can interleave `\u200B` into dangerous protocols (e.g., `java\u200Bscript:`) to evade detection while still executing in lenient contexts.
+**Prevention:** Explicitly strip a broader range of control and format characters (including `\u200B-\u200D`, `\uFEFF`) during input normalization before security checks.

--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -27,6 +27,17 @@ describe('Security Utils', () => {
       expect(isDangerousUrl('\x00javascript:alert(1)')).toBe(true);
     });
 
+    it('detects zero-width characters bypass attempts', () => {
+      // Zero Width Space \u200B
+      expect(isDangerousUrl('java\u200Bscript:alert(1)')).toBe(true);
+      // Zero Width Non-Joiner \u200C
+      expect(isDangerousUrl('java\u200Cscript:alert(1)')).toBe(true);
+      // Zero Width Joiner \u200D
+      expect(isDangerousUrl('java\u200Dscript:alert(1)')).toBe(true);
+      // Zero Width No-Break Space \uFEFF
+      expect(isDangerousUrl('java\uFEFFscript:alert(1)')).toBe(true);
+    });
+
     it('allows safe protocols', () => {
       expect(isDangerousUrl('https://example.com')).toBe(false);
       expect(isDangerousUrl('http://example.com')).toBe(false);

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -8,7 +8,9 @@ export const safeJsonLdStringify = (data: any): string => {
                              .replace(/&/g, '\\u0026');
 };
 
-const CONTROL_CHARS_REGEX = /[\x00-\x1F\x7F-\x9F\s]+/g;
+// Includes standard control chars, unicode control chars (0080-009F), whitespace,
+// and invisible chars like Zero Width Space (200B), ZWNJ (200C), ZWJ (200D), BOM (FEFF)
+const CONTROL_CHARS_REGEX = /[\x00-\x1F\x7F-\x9F\s\u200B-\u200D\uFEFF]+/g;
 
 const DANGEROUS_PROTOCOLS = [
   'javascript:',


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Invisible Character URL Filter Bypass

🚨 Severity: HIGH
💡 Vulnerability: URL sanitization filters using standard regex whitespace (`\s`) can be bypassed using invisible Unicode characters like Zero Width Space (`\u200B`), which are ignored by some URL parsers but not matched by `\s`. An attacker could construct a malicious URL like `java\u200Bscript:alert(1)` that passes the filter but executes JavaScript in lenient contexts.
🎯 Impact: Potential XSS if the generated QR code is scanned by a reader that executes the URL in a browser context that ignores these characters.
🔧 Fix: Updated `CONTROL_CHARS_REGEX` in `src/utils/security.ts` to explicitly include `\u200B-\u200D` and `\uFEFF`.
✅ Verification: Ran `npm test src/utils/security.test.ts` to confirm the new test cases pass and existing functionality is preserved.

---
*PR created automatically by Jules for task [4745211931201367012](https://jules.google.com/task/4745211931201367012) started by @fderuiter*