### PR TITLE
🛡️ Sentinel: Block Obscure Dangerous Protocols

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Input validation filters using standard regex whitespace (`\s`) can be bypassed using invisible Unicode characters like Zero Width Space (`\u200B`), which are ignored by some URL parsers but not matched by `\s`.
 **Learning:** `\s` in JavaScript RegExp does not include all invisible Unicode characters. Attackers can interleave `\u200B` into dangerous protocols (e.g., `java\u200Bscript:`) to evade detection while still executing in lenient contexts.
 **Prevention:** Explicitly strip a broader range of control and format characters (including `\u200B-\u200D`, `\uFEFF`) during input normalization before security checks.
+
+## 2026-05-12 - Obscure Dangerous Protocols
+**Vulnerability:** Blocking only common XSS vectors (`javascript:`, `data:`, `file:`) leaves gaps for obscure or browser-specific protocols like `blob:`, `filesystem:`, or legacy scripting schemes (`jscript:`, `mocha:`).
+**Learning:** Attackers can utilize generated `blob:` URLs or legacy IE protocols to execute code or spoof content if the validation allowlist is too permissive or the blocklist is too narrow.
+**Prevention:** Maintain a comprehensive blocklist of dangerous protocols, including `blob:`, `filesystem:`, and legacy scripting schemes, to practice defense-in-depth against protocol handler abuse.

--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -20,6 +20,24 @@ describe('Security Utils', () => {
       expect(isDangerousUrl('file:///etc/passwd')).toBe(true);
     });
 
+    it('detects blob: protocol', () => {
+      expect(isDangerousUrl('blob:https://example.com/uuid')).toBe(true);
+    });
+
+    it('detects filesystem: protocol', () => {
+      expect(isDangerousUrl('filesystem:http://example.com/temporary/')).toBe(true);
+    });
+
+    it('detects legacy scripting protocols', () => {
+      expect(isDangerousUrl('jscript:alert(1)')).toBe(true);
+      expect(isDangerousUrl('wscript:alert(1)')).toBe(true);
+      expect(isDangerousUrl('mocha:alert(1)')).toBe(true);
+    });
+
+    it('detects about: protocol', () => {
+      expect(isDangerousUrl('about:blank')).toBe(true);
+    });
+
     it('detects protocols with leading whitespace or control characters', () => {
       expect(isDangerousUrl('  javascript:alert(1)')).toBe(true);
       expect(isDangerousUrl('\njavascript:alert(1)')).toBe(true);

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -18,11 +18,17 @@ const DANGEROUS_PROTOCOLS = [
   'file:',
   'data:',
   'mk:',
+  'blob:',
+  'filesystem:',
+  'jscript:',
+  'wscript:',
+  'mocha:',
+  'about:',
 ];
 
 /**
  * Checks if a URL string contains a dangerous protocol.
- * Dangerous protocols: javascript:, vbscript:, file:, data:, mk:
+ * Dangerous protocols: javascript:, vbscript:, file:, data:, mk:, blob:, filesystem:, jscript:, wscript:, mocha:, about:
  */
 export const isDangerousUrl = (url: string | undefined): boolean => {
   if (!url) return false;


### PR DESCRIPTION
🛡️ Sentinel: [Security Enhancement] Block Obscure Dangerous Protocols

**Summary:**
Expanded the `DANGEROUS_PROTOCOLS` blocklist in `src/utils/security.ts` to include `blob:`, `filesystem:`, `jscript:`, `wscript:`, `mocha:`, and `about:`.

**Security Impact:**
Prevents attackers from bypassing protocol validation using obscure or browser-specific schemes that could lead to XSS (e.g., `blob:` with HTML content) or other client-side attacks.

**Verification:**
Ran `pnpm test` and confirmed all tests pass, including new test cases in `src/utils/security.test.ts`.

---
*PR created automatically by Jules for task [10523281110052358557](https://jules.google.com/task/10523281110052358557) started by @fderuiter*