### PR TITLE
🛡️ Shield: Fix flaky canvas tests and remove sleeps

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -27,3 +27,7 @@
 ## 2025-02-18 - [Header Injection in Email Schemas]
 **Discovery:** `constructEmailString` did not sanitize newlines from email inputs, allowing attackers to inject arbitrary headers (e.g. `cc:`) into `mailto:` links via crafted input (e.g., `user@example.com\ncc:attacker`).
 **Defense:** Updated `sanitizeInput` in `src/utils/security.ts` to strictly strip all control characters (0x00-0x1F, 0x7F-0x9F), neutralizing newline injection attacks across email and other URI schemes.
+
+## 2026-02-11 - Act Warnings in Canvas Tests
+**Discovery:** `QRCanvas.test.tsx` triggered multiple `act(...)` warnings because manual `img.onload` calls updated state outside the React test loop. Additionally, `QRCanvasBorder.test.tsx` used brittle `setTimeout` calls to wait for async rendering.
+**Defense:** Wrapped all manual event triggers in `act(...)` and replaced `setTimeout` with `waitFor(...)` to ensure tests are deterministic and free of console noise.

--- a/src/components/QRCanvas.test.tsx
+++ b/src/components/QRCanvas.test.tsx
@@ -17,7 +17,7 @@
 */
 
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach, Mock } from 'vitest';
 import QRCanvas from './QRCanvas';
 import { DEFAULT_CONFIG } from '../constants';
@@ -211,10 +211,12 @@ describe('QRCanvas Component', () => {
     const img = createdImages[0];
     
     // Simulate load
-    if (img.onload) {
-        img.complete = true;
-        img.onload();
-    }
+    act(() => {
+      if (img.onload) {
+          img.complete = true;
+          img.onload();
+      }
+    });
 
     await waitFor(() => {
         expect(mockContext.drawImage).toHaveBeenCalled();
@@ -234,7 +236,9 @@ describe('QRCanvas Component', () => {
           expect(createdImages.length).toBeGreaterThan(0);
       });
       const img = createdImages[0];
-      if (img.onload) { img.complete = true; img.onload(); }
+      act(() => {
+        if (img.onload) { img.complete = true; img.onload(); }
+      });
 
       await waitFor(() => {
           // Should draw a circle background (arc)
@@ -256,7 +260,9 @@ describe('QRCanvas Component', () => {
           expect(createdImages.length).toBeGreaterThan(0);
       });
       const img = createdImages[0];
-      if (img.onload) { img.complete = true; img.onload(); }
+      act(() => {
+        if (img.onload) { img.complete = true; img.onload(); }
+      });
 
       await waitFor(() => {
           // Should draw a rect background
@@ -278,11 +284,15 @@ describe('QRCanvas Component', () => {
           expect(createdImages.length).toBeGreaterThan(0);
       });
       const img = createdImages[0];
-      if (img.onload) { img.complete = true; img.onload(); }
 
       // Reset mock to check for subsequent calls
       mockContext.fillRect.mockClear();
       mockContext.arc.mockClear();
+      mockContext.drawImage.mockClear();
+
+      act(() => {
+        if (img.onload) { img.complete = true; img.onload(); }
+      });
 
       await waitFor(() => {
           expect(mockContext.drawImage).toHaveBeenCalled();
@@ -313,9 +323,11 @@ describe('QRCanvas Component', () => {
       const img = createdImages[0];
 
       // Simulate error
-      if (img.onerror) {
-          img.onerror();
-      }
+      act(() => {
+        if (img.onerror) {
+            img.onerror();
+        }
+      });
 
       // Should still finish rendering but without logo
       await waitFor(() => {
@@ -385,7 +397,9 @@ describe('QRCanvas Component', () => {
     });
 
     const img = createdImages[0];
-    if (img.onload) { img.complete = true; img.onload(); }
+    act(() => {
+      if (img.onload) { img.complete = true; img.onload(); }
+    });
 
     await waitFor(() => {
         // Find the logo background call. It should be the one centered.

--- a/src/components/QRCanvasBorder.test.tsx
+++ b/src/components/QRCanvasBorder.test.tsx
@@ -18,7 +18,7 @@
 
 
 import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import QRCanvas from './QRCanvas';
 import { DEFAULT_CONFIG } from '../constants';
 import { QRConfig } from '../types';
@@ -69,7 +69,9 @@ describe('QRCanvas Border Rendering', () => {
 
     render(<QRCanvas config={config} size={100} />);
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await waitFor(() => {
+        expect(mockContext.fillRect).toHaveBeenCalled();
+    });
 
     const fillRectCalls = mockContext.fillRect.mock.calls;
 
@@ -100,7 +102,10 @@ describe('QRCanvas Border Rendering', () => {
 
     mockContext.fillRect.mockClear();
     render(<QRCanvas config={config} size={100} />);
-    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    await waitFor(() => {
+        expect(mockContext.fillRect).toHaveBeenCalled();
+    });
 
     const fillRectCalls = mockContext.fillRect.mock.calls;
 


### PR DESCRIPTION
🛑 **Vulnerability:** 
- `QRCanvas.test.tsx` was generating multiple "An update to QRCanvas inside a test was not wrapped in act(...)" warnings because `img.onload` callbacks were updating state outside the test loop.
- `QRCanvasBorder.test.tsx` relied on `setTimeout(100)` to wait for async operations, which is brittle and slow.

🛡️ **Defense:** 
- Wrapped all `img.onload` and `img.onerror` calls in `act(...)`.
- Replaced `setTimeout` with `waitFor` from `@testing-library/react` to deterministically wait for canvas operations.
- Adjusted mock clearing logic to ensure assertions are correct.

🔬 **Verification:** 
- Run `npm test` to verify all tests pass without console warnings.
- Specifically check `src/components/QRCanvas.test.tsx` and `src/components/QRCanvasBorder.test.tsx`.

📊 **Impact:** 
- Eliminates console noise during testing.
- Makes tests faster (no fixed 100ms waits) and more reliable (waits for condition).

---
*PR created automatically by Jules for task [6980263114030856864](https://jules.google.com/task/6980263114030856864) started by @fderuiter*