### PR TITLE
🛡️ Sentinel: [HIGH] Fix phone number sanitization to use strict whitelist

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -22,3 +22,13 @@
 **Vulnerability:** Blocking only common XSS vectors (`javascript:`, `data:`, `file:`) leaves gaps for obscure or browser-specific protocols like `blob:`, `filesystem:`, or legacy scripting schemes (`jscript:`, `mocha:`).
 **Learning:** Attackers can utilize generated `blob:` URLs or legacy IE protocols to execute code or spoof content if the validation allowlist is too permissive or the blocklist is too narrow.
 **Prevention:** Maintain a comprehensive blocklist of dangerous protocols, including `blob:`, `filesystem:`, and legacy scripting schemes, to practice defense-in-depth against protocol handler abuse.
+
+## 2025-02-18 - Phone Number Sanitization Gap
+**Vulnerability:** The  function used a blacklist approach (removing only spaces and specific chars), allowing injection of letters and script tags into `tel:` and `sms:` URIs.
+**Learning:** Blacklists are prone to incompleteness. A previous memory claimed strict whitelisting was in place, but the code did not reflect this, leading to a false sense of security.
+**Prevention:** Implement strict whitelisting (`/[^0-9+*#\-().]/g`) for phone numbers and verify implementation against security claims in documentation/memory.
+
+## 2025-02-18 - Phone Number Sanitization Gap
+**Vulnerability:** The `cleanPhoneNumber` function used a blacklist approach (removing only spaces and specific chars), allowing injection of letters and script tags into `tel:` and `sms:` URIs.
+**Learning:** Blacklists are prone to incompleteness. A previous memory claimed strict whitelisting was in place, but the code did not reflect this, leading to a false sense of security.
+**Prevention:** Implement strict whitelisting (`/[^0-9+*#\-().]/g`) for phone numbers and verify implementation against security claims in documentation/memory.

--- a/src/utils/qrHelpers_SadPaths.test.ts
+++ b/src/utils/qrHelpers_SadPaths.test.ts
@@ -120,11 +120,12 @@ describe('QR Helpers Sad Paths', () => {
         message: 'hello'
       };
       // If we don't sanitize the number, we get sms:123?body=injected?body=hello
-      // We expect the number to be cleaned of URI control characters
+      // We expect the number to be cleaned of URI control characters AND non-phone chars
       const result = constructSmsString(data);
       // It should NOT contain two 'body=' params or two '?'
       expect(result).not.toMatch(/\?.*\?/);
-      expect(result).toBe('sms:123bodyinjected?body=hello');
+      // With strict whitelist, 'bodyinjected' is removed
+      expect(result).toBe('sms:123?body=hello');
     });
   });
 });

--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -110,9 +110,16 @@ describe('Security Utils', () => {
           expect(cleanPhoneNumber('123 456:789')).toBe('123456789');
       });
 
-      it('removes URI control characters', () => {
-          expect(cleanPhoneNumber('123?body=hacked')).toBe('123bodyhacked');
-          expect(cleanPhoneNumber('123&foo=bar')).toBe('123foobar');
+      it('removes URI control characters and non-whitelisted chars', () => {
+          expect(cleanPhoneNumber('123?body=hacked')).toBe('123');
+          expect(cleanPhoneNumber('123&foo=bar')).toBe('123');
+      });
+
+      it('enforces strict whitelist', () => {
+         expect(cleanPhoneNumber('1-800-ABC-DEFG')).toBe('1-800--'); // Letters removed
+         expect(cleanPhoneNumber('+1 (555) 123-4567')).toBe('+1(555)123-4567');
+         expect(cleanPhoneNumber('<script>alert(1)</script>')).toBe('(1)');
+         expect(cleanPhoneNumber('123#*')).toBe('123#*');
       });
   });
 

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -57,10 +57,11 @@ export const isDangerousUrl = (url: string | undefined): boolean => {
 };
 
 /**
- * Removes spaces, colons, and URI control characters from a phone number string.
+ * Removes all characters that are not digits or valid phone symbols (+, *, #, -, ., (, )).
+ * This prevents injection of arbitrary characters into tel: or sms: URIs.
  */
 export const cleanPhoneNumber = (number: string): string => {
-  return number.replace(/[\s:?&=]+/g, '');
+  return number.replace(/[^0-9+*#\-().]/g, '');
 };
 
 /**


### PR DESCRIPTION
The `cleanPhoneNumber` function was using a blacklist approach which allowed non-phone characters (letters, symbols like `<`) to pass through into `tel:` and `sms:` URIs. This change enforces a strict whitelist of allowed characters (digits, `+`, `*`, `#`, `-`, `.`, `(`, `)`), significantly reducing the attack surface for URI injection. It aligns the implementation with best practices and previous security claims.

---
*PR created automatically by Jules for task [15550637647370519350](https://jules.google.com/task/15550637647370519350) started by @fderuiter*