### PR TITLE
🧹 Resolve Unsafe Content Security Policy for style-src

### DIFF
--- a/src/components/QRCanvas.tsx
+++ b/src/components/QRCanvas.tsx
@@ -19,7 +19,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { QRConfig, SocialFormat, TemplateStyle } from '../types';
 import { drawQR } from '../utils/qrRenderer';
-import { drawWithTemplate, getAspectRatioCss, SOCIAL_DIMENSIONS } from '../utils/templateRenderer';
+import { drawWithTemplate, SOCIAL_DIMENSIONS } from '../utils/templateRenderer';
 import { useImage } from '../utils/hooks';
 
 /**
@@ -137,14 +137,19 @@ const QRCanvas: React.FC<QRCanvasProps> = ({ config, size = 1024, className }) =
   const typeLabel = config.type.charAt(0).toUpperCase() + config.type.slice(1).toLowerCase();
   const ariaLabel = `QR Code for ${typeLabel} - ${config.value ? 'Scan to view content' : 'Empty'}`;
 
-  const aspectRatioCss = getAspectRatioCss(config.socialFormat);
+  const aspectRatioClass = {
+    [SocialFormat.SQUARE_1_1]: 'aspect-square',
+    [SocialFormat.PORTRAIT_4_5]: 'aspect-[4/5]',
+    [SocialFormat.STORY_9_16]: 'aspect-[9/16]',
+  }[config.socialFormat];
+
+  const containerClasses = className ? `${className} ${aspectRatioClass}` : aspectRatioClass;
 
   return (
-    <div className={className} style={{ aspectRatio: aspectRatioCss }}>
+    <div className={containerClasses}>
       <canvas
         ref={canvasRef}
-        className="w-full h-auto block"
-        style={{ aspectRatio: aspectRatioCss }}
+        className={`w-full h-auto block ${aspectRatioClass}`}
         role="img"
         aria-label={ariaLabel}
       />

--- a/src/components/StyleControls.test.tsx
+++ b/src/components/StyleControls.test.tsx
@@ -56,9 +56,9 @@ describe('StyleControls Component', () => {
      const starPath = container.querySelector('path[d^="M12 2l3.09 6.26"]');
      expect(starPath).toBeInTheDocument();
 
-     // Hive uses clipPath
+     // Hive uses SVG polygon
      // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-     const hiveElements = container.querySelectorAll('div[style*="polygon(50% 0%"]');
+     const hiveElements = container.querySelectorAll('polygon[points="50,0 100,25 100,75 50,100 0,75 0,25"]');
      expect(hiveElements.length).toBeGreaterThan(0);
   });
 

--- a/src/components/style-controls/ColorControls.tsx
+++ b/src/components/style-controls/ColorControls.tsx
@@ -46,14 +46,15 @@ export const ColorControls: React.FC<ColorControlsProps> = ({ config, onChange }
             className="group relative w-10 h-10 rounded-lg shadow-sm hover:scale-110 transition-transform duration-200 ring-1 ring-slate-200 dark:ring-slate-700 overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
             title={preset.label}
           >
-            {/* Background */}
-            <div className="absolute inset-0" style={{ backgroundColor: preset.bg }}></div>
-
-            {/* Foreground Ring (Simulating Modules) */}
-            <div className="absolute inset-1.5 border-[3px] rounded-sm" style={{ borderColor: preset.fg }}></div>
-
-            {/* Eye Center */}
-            <div className="absolute inset-[11px] rounded-[1px]" style={{ backgroundColor: preset.eye }}></div>
+            {/* Use SVG presentation attributes instead of inline styles for CSP compliance */}
+            <svg viewBox="0 0 40 40" className="absolute inset-0 w-full h-full">
+              {/* Background */}
+              <rect width="40" height="40" fill={preset.bg} />
+              {/* Foreground Ring (Simulating Modules) */}
+              <rect x="6" y="6" width="28" height="28" rx="2" fill="none" stroke={preset.fg} strokeWidth="6" />
+              {/* Eye Center */}
+              <rect x="11" y="11" width="18" height="18" rx="1" fill={preset.eye} />
+            </svg>
           </button>
         ))}
       </div>

--- a/src/components/ui/PatternModule.tsx
+++ b/src/components/ui/PatternModule.tsx
@@ -15,9 +15,13 @@ export const PatternModule: React.FC<{ style: QRStyle }> = ({ style }) => {
     );
   }
   if (style === QRStyle.HIVE) {
-    // Hexagon clip path
+    // Hexagon
     return (
-      <div className="flex items-center justify-center bg-current" style={{ clipPath: 'polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%)' }} />
+      <div className="flex items-center justify-center">
+        <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
+          <polygon points="50,0 100,25 100,75 50,100 0,75 0,25" />
+        </svg>
+      </div>
     );
   }
   if (style === QRStyle.SWISS) {
@@ -27,7 +31,7 @@ export const PatternModule: React.FC<{ style: QRStyle }> = ({ style }) => {
     return <div className="bg-current rounded-sm" />;
   }
   if (style === QRStyle.FLUID) {
-    return <div className="bg-current rounded-lg" style={{ borderRadius: '50%' }} />;
+    return <div className="bg-current rounded-full" />;
   }
   if (style === QRStyle.CIRCUIT) {
     return (
@@ -38,7 +42,13 @@ export const PatternModule: React.FC<{ style: QRStyle }> = ({ style }) => {
     );
   }
   if (style === QRStyle.GRUNGE) {
-    return <div className="bg-current" style={{ clipPath: 'polygon(10% 0, 100% 10%, 90% 100%, 0 90%)' }} />;
+    return (
+      <div className="flex items-center justify-center">
+        <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
+          <polygon points="10,0 100,10 90,100 0,90" />
+        </svg>
+      </div>
+    );
   }
   // Standard and others
   return (

--- a/src/layouts/Head.tsx
+++ b/src/layouts/Head.tsx
@@ -157,10 +157,10 @@ export default function HeadDefault() {
       {/*
         Content Security Policy (CSP)
         - script-src 'unsafe-inline': Required for JSON-LD scripts and Vike hydration in SSG.
-        - style-src 'unsafe-inline': Required for the font loading hack and CSS extraction.
+        - style-src: Removed 'unsafe-inline' by refactoring font loading and dynamic preview styles.
         - object-src 'none': Prevents Flash/Java applets.
       */}
-      <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" />
+      <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests;" />
 
       {/*
         Note: 'viewport' and 'description' are handled by Vike/Config to avoid duplicates.
@@ -208,17 +208,10 @@ export default function HeadDefault() {
 
       {/*
          Load fonts synchronously to prevent Layout Shifts (CLS).
-         While async loading improves FCP, the shift when the font swaps
-         negatively impacts the user experience and CLS score.
+         Standard link tag is render-blocking which ensures fonts are ready
+         before first paint, avoiding layout shifts.
       */}
-      {/* Use a raw style tag to inject the link with onload attribute, ensuring it works in SSG */}
-      <style dangerouslySetInnerHTML={{ __html: `
-        </style>
-        <link rel="preload" href="${fontUrl}" as="style" />
-        <link rel="stylesheet" href="${fontUrl}" media="print" onload="this.media='all'" />
-        <noscript><link rel="stylesheet" href="${fontUrl}" /></noscript>
-        <style>`
-      }} />
+      <link rel="stylesheet" href={fontUrl} />
     </>
   );
 }


### PR DESCRIPTION
🎯 **What:** This change removes `style-src 'unsafe-inline'` from the Content Security Policy (CSP).

💡 **Why:** Having `unsafe-inline` in the CSP is a security risk. By refactoring the "font loading hack" and other dynamic inline styles, we can maintain a more restrictive and secure policy without sacrificing functionality or user experience.

✅ **Verification:** 
- CSP header verified to be more restrictive via Playwright.
- Unit tests for `Head`, `StyleControls`, and `QRCanvas` pass.
- Visual verification confirmed that pattern previews and color themes still work correctly using the new SVG-based implementation.

✨ **Result:** Improved application security and maintainability.

---
*PR created automatically by Jules for task [16952786444794467338](https://jules.google.com/task/16952786444794467338) started by @fderuiter*