### PR TITLE
🔨 Forge: [Extract Style Controls Barrel File]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,0 +1,1 @@
+## 2025-04-28 - [Barrel File for Style Controls] **Context:** [Multiple individual imports in StyleControls.tsx clutters the top of the file] **Decision:** [Use a barrel file (index.ts) to re-export related components from style-controls directory] **Consequence:** [Cleaner imports in consumers, but requires maintaining the barrel file]

--- a/src/components/StyleControls.tsx
+++ b/src/components/StyleControls.tsx
@@ -19,12 +19,14 @@
 
 import React from 'react';
 import { QRConfig } from '../types';
-import { BorderControls } from './style-controls/BorderControls';
-import { PatternControls } from './style-controls/PatternControls';
-import { ColorControls } from './style-controls/ColorControls';
-import { LogoControls } from './style-controls/LogoControls';
-import { AdvancedControls } from './style-controls/AdvancedControls';
-import { LayoutControls } from './style-controls/LayoutControls';
+import {
+  BorderControls,
+  PatternControls,
+  ColorControls,
+  LogoControls,
+  AdvancedControls,
+  LayoutControls
+} from './style-controls';
 
 /**
  * Props for the StyleControls component.

--- a/src/components/style-controls/index.ts
+++ b/src/components/style-controls/index.ts
@@ -1,0 +1,6 @@
+export * from './AdvancedControls';
+export * from './BorderControls';
+export * from './ColorControls';
+export * from './LayoutControls';
+export * from './LogoControls';
+export * from './PatternControls';


### PR DESCRIPTION
🛑 **The Smell:** `src/components/StyleControls.tsx` had multiple individual imports for each control component (`BorderControls`, `PatternControls`, `ColorControls`, etc.), cluttering the top of the file and making future additions repetitive.

🔨 **The Fix:** Extracted these component exports into a central barrel file at `src/components/style-controls/index.ts` and updated the imports in `StyleControls.tsx` to import from the directory index.

🧠 **The Why:** Cleans up the top of consumer files, making them easier to read. Promotes a standard pattern where consumers shouldn't need to know the exact internal file structure of a module folder.

⚠️ **Risk:** Low - pure structural refactor. Type checking and tests all pass. Recorded this decision in the Forge ADR journal.

---
*PR created automatically by Jules for task [4044288719959647103](https://jules.google.com/task/4044288719959647103) started by @fderuiter*