### PR TITLE
🛡️ Sentinel: [MEDIUM] Add client-side image upload validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Client-Side Image Upload Validation
+**Vulnerability:** Lack of file size and type validation for local client-side image uploads before processing with `FileReader`. While not an immediate server-side risk, large files could freeze the browser tab (resource exhaustion) or malicious files could be inadvertently processed.
+**Learning:** `FileReader.readAsDataURL` loads the entire file into a base64 string in memory. Without limits, users could upload multi-gigabyte files, crashing the application.
+**Prevention:** Implement a `validateImageUpload` utility function (e.g., in `src/utils/security.ts`) that strictly checks `file.size` (e.g., 2MB limit) and `file.type` against a whitelist of allowed MIME types (JPEG, PNG, WebP, SVG) *before* passing the file to `FileReader`.

--- a/src/components/style-controls/BorderControls.tsx
+++ b/src/components/style-controls/BorderControls.tsx
@@ -1,9 +1,10 @@
-import React, { useRef, useMemo } from 'react';
+import React, { useRef, useMemo, useState } from 'react';
 import { QRConfig, BorderStyle, BorderTextPosition, BorderLogoPosition } from '../../types';
 import { Upload, X, AlertTriangle } from 'lucide-react';
 import { getContrastRatio } from '../../utils/colorUtils';
 import { ColorInput } from '../ui/ColorInput';
 import { RangeInput } from '../ui/RangeInput';
+import { validateImageUpload } from '../../utils/security';
 
 interface BorderControlsProps {
   config: QRConfig;
@@ -12,10 +13,17 @@ interface BorderControlsProps {
 
 export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange }) => {
   const borderLogoInputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const handleBorderLogoUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
+    setError(null);
     if (file) {
+      const validationError = validateImageUpload(file);
+      if (validationError) {
+        setError(validationError);
+        return;
+      }
       const reader = new FileReader();
       reader.onload = (event) => {
         onChange({ borderLogoUrl: event.target?.result as string });
@@ -161,6 +169,7 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
                 onChange={handleBorderLogoUpload}
               />
             </div>
+            {error && <div className="mt-1 text-xs text-rose-600 dark:text-rose-400">{error}</div>}
             {config.borderLogoUrl && (
               <div className="mt-2">
                 <select

--- a/src/components/style-controls/LogoControls.tsx
+++ b/src/components/style-controls/LogoControls.tsx
@@ -1,8 +1,9 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { QRConfig, LogoPaddingStyle } from '../../types';
 import { Upload, X, Square, Circle, Minus } from 'lucide-react';
 import { ColorInput } from '../ui/ColorInput';
 import { RangeInput } from '../ui/RangeInput';
+import { validateImageUpload } from '../../utils/security';
 
 interface LogoControlsProps {
   config: QRConfig;
@@ -11,10 +12,17 @@ interface LogoControlsProps {
 
 export const LogoControls: React.FC<LogoControlsProps> = ({ config, onChange }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const handleLogoUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
+    setError(null);
     if (file) {
+      const validationError = validateImageUpload(file);
+      if (validationError) {
+        setError(validationError);
+        return;
+      }
       const reader = new FileReader();
       reader.onload = (event) => {
         onChange({ logoUrl: event.target?.result as string });
@@ -45,6 +53,7 @@ export const LogoControls: React.FC<LogoControlsProps> = ({ config, onChange }) 
           </div>
           <span className="text-sm font-medium">Upload Logo</span>
           <span className="text-xs text-slate-600 dark:text-slate-400 mt-1">PNG, JPG (Square recommended)</span>
+          {error && <span className="text-xs text-rose-600 dark:text-rose-400 mt-2">{error}</span>}
         </button>
       ) : (
         <div className="bg-slate-50 dark:bg-slate-800/50 rounded-xl p-4 border border-slate-200 dark:border-slate-700 space-y-5">

--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -17,7 +17,7 @@
 */
 
 import { describe, it, expect } from 'vitest';
-import { isDangerousUrl, safeJsonLdStringify, cleanPhoneNumber, sanitizeInput } from './security';
+import { isDangerousUrl, safeJsonLdStringify, cleanPhoneNumber, sanitizeInput, validateImageUpload } from './security';
 
 describe('Security Utils', () => {
   describe('isDangerousUrl', () => {
@@ -138,3 +138,39 @@ describe('Security Utils', () => {
       });
   });
 });
+
+  describe('validateImageUpload', () => {
+      it('returns null for valid file types and sizes', () => {
+          const validPng = new File([''], 'test.png', { type: 'image/png' });
+          expect(validateImageUpload(validPng)).toBeNull();
+
+          const validJpeg = new File([''], 'test.jpg', { type: 'image/jpeg' });
+          expect(validateImageUpload(validJpeg)).toBeNull();
+
+          const validWebp = new File([''], 'test.webp', { type: 'image/webp' });
+          expect(validateImageUpload(validWebp)).toBeNull();
+
+          const validSvg = new File(['<svg></svg>'], 'test.svg', { type: 'image/svg+xml' });
+          expect(validateImageUpload(validSvg)).toBeNull();
+      });
+
+      it('returns error for unsupported file types', () => {
+          const invalidGif = new File([''], 'test.gif', { type: 'image/gif' });
+          expect(validateImageUpload(invalidGif)).toBe('Invalid file type. Only JPEG, PNG, WebP, and SVG are allowed.');
+
+          const invalidTxt = new File(['text'], 'test.txt', { type: 'text/plain' });
+          expect(validateImageUpload(invalidTxt)).toBe('Invalid file type. Only JPEG, PNG, WebP, and SVG are allowed.');
+      });
+
+      it('returns error for files larger than 2MB', () => {
+          const largeFile = new File([''], 'large.png', { type: 'image/png' });
+          Object.defineProperty(largeFile, 'size', { value: 2 * 1024 * 1024 + 1 });
+          expect(validateImageUpload(largeFile)).toBe('File size exceeds the 2MB limit.');
+      });
+
+      it('returns null for files exactly 2MB', () => {
+          const borderFile = new File([''], 'border.png', { type: 'image/png' });
+          Object.defineProperty(borderFile, 'size', { value: 2 * 1024 * 1024 });
+          expect(validateImageUpload(borderFile)).toBeNull();
+      });
+  });

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -79,3 +79,23 @@ export const sanitizeInput = (str: string): string => {
   const noControl = str.replace(REGEX_STRICT_CONTROL_CHARS, '');
   return noControl.split('?')[0];
 };
+
+/**
+ * Validates an uploaded image file for size and type.
+ * Enforces a 2MB size limit and allows jpeg, png, webp, and svg formats.
+ * @param file The file to validate.
+ * @returns A string with an error message if invalid, or null if valid.
+ */
+export const validateImageUpload = (file: File): string | null => {
+  const MAX_SIZE = 2 * 1024 * 1024; // 2MB
+  if (file.size > MAX_SIZE) {
+    return 'File size exceeds the 2MB limit.';
+  }
+
+  const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml'];
+  if (!allowedTypes.includes(file.type)) {
+    return 'Invalid file type. Only JPEG, PNG, WebP, and SVG are allowed.';
+  }
+
+  return null;
+};


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unrestricted client-side image file uploads in `LogoControls.tsx` and `BorderControls.tsx`. Because `FileReader.readAsDataURL()` loads the entire file into a base64 string in memory, uploading massive files (e.g., multi-gigabyte ISOs) could freeze or crash the user's browser tab. Furthermore, unsupported file types could lead to unexpected rendering behavior.
🎯 **Impact:** Client-side Denial of Service (DoS) via resource exhaustion, resulting in a degraded user experience.
🔧 **Fix:** Implemented a new `validateImageUpload` utility in `src/utils/security.ts` to strictly enforce a 2MB file size limit and an allowlist of MIME types (`image/jpeg`, `image/png`, `image/webp`, `image/svg+xml`). Integrated this check into `LogoControls` and `BorderControls` before `FileReader` is invoked, and added UI state to surface validation errors clearly to the user.
✅ **Verification:** Ran `pnpm test` and verified that the newly added `validateImageUpload` tests pass, and existing style control tests succeed. UI logic cleanly bails out and sets the error state when an invalid file is selected.

---
*PR created automatically by Jules for task [4533729455026046242](https://jules.google.com/task/4533729455026046242) started by @fderuiter*