### PR TITLE
✍️ Scribe: [README improvement] Document Playwright E2E test setup

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,3 @@
+## 2026-04-29 - Playwright Installation Requirement
+**Insight:** Running End-to-End tests via `pnpm test:e2e` fails consistently on fresh environments because Playwright browsers are not installed by default with `pnpm install`.
+**Guideline:** Always document the requirement to run `pnpm exec playwright install` before attempting to run Playwright E2E tests in a new environment.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pnpm preview
 
 ### Running Tests
 
-To run the test suite (Vitest):
+To run the unit test suite (Vitest):
 
 ```bash
 pnpm test
@@ -106,6 +106,17 @@ To run coverage reports:
 ```bash
 pnpm test -- run --coverage
 ```
+
+To run the End-to-End test suite (Playwright):
+
+1. Install Playwright browsers (required on first run):
+   ```bash
+   pnpm exec playwright install
+   ```
+2. Run the tests:
+   ```bash
+   pnpm test:e2e
+   ```
 
 ### Quality Assurance
 


### PR DESCRIPTION
💡 **What:** 
Updated `README.md` to explicitly document the `test:e2e` Playwright script and added the mandatory `pnpm exec playwright install` prerequisite step. Also created an entry in Scribe's journal (`.jules/scribe.md`).

🎯 **Why:** 
Running `pnpm test:e2e` consistently fails on fresh environments because Playwright browsers are not installed by default with `pnpm install`. This undocumented "ghost script" and missing setup step acts as a hidden onboarding trap for new contributors trying to run the full test suite.

🧠 **Cognitive Impact:** 
Fixes a "first-run crash" scenario. New developers will no longer have to dig through Playwright console errors or decipher why a standard `test:e2e` script fails immediately after cloning and installing the repository. 

📖 **Preview:** 
```markdown
To run the End-to-End test suite (Playwright):

1. Install Playwright browsers (required on first run):
   ```bash
   pnpm exec playwright install
   ```
2. Run the tests:
   ```bash
   pnpm test:e2e
   ```
```

---
*PR created automatically by Jules for task [1650512678810798208](https://jules.google.com/task/1650512678810798208) started by @fderuiter*