### PR TITLE
🛡️ Shield: [test improvement/fix] Add sad path coverage for MeetingInput unknown URLs

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,7 +1,0 @@
-## 2025-04-28 - Missing Test Coverage for Input Components
-**Discovery:** The `MeetingInput` and `SocialInput` form components lacked test coverage for basic behavior, UI rendering, and mock interactions.
-**Defense:** Ensure all interactive form components (`*Input.tsx`) include unit tests adjacent to the source code (e.g. `*Input.test.tsx`) that verify UI presence, correct state mappings, and correct `onChange` handlers via mock functions using the AAA (Arrange, Act, Assert) testing pattern.
-
-## 2025-05-18 - Missing Sad Path for Meeting URLs
-**Discovery:** The `MeetingInput` component was missing a "Sad Path" test case to verify its behavior when provided with an unrecognized or completely generic URL (e.g. `https://example.com/unknown-meeting`). Without this, there was a risk that unknown inputs could falsely trigger the display of specific meeting details or IDs, leading to UI bugs or confusion.
-**Defense:** Explicitly test boundary conditions and unrecognized formats (sad paths) for components that perform pattern matching or parsing, ensuring the UI degrades gracefully or ignores invalid data instead of attempting to render it.

--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,3 +1,7 @@
 ## 2025-04-28 - Missing Test Coverage for Input Components
 **Discovery:** The `MeetingInput` and `SocialInput` form components lacked test coverage for basic behavior, UI rendering, and mock interactions.
 **Defense:** Ensure all interactive form components (`*Input.tsx`) include unit tests adjacent to the source code (e.g. `*Input.test.tsx`) that verify UI presence, correct state mappings, and correct `onChange` handlers via mock functions using the AAA (Arrange, Act, Assert) testing pattern.
+
+## 2025-05-18 - Missing Sad Path for Meeting URLs
+**Discovery:** The `MeetingInput` component was missing a "Sad Path" test case to verify its behavior when provided with an unrecognized or completely generic URL (e.g. `https://example.com/unknown-meeting`). Without this, there was a risk that unknown inputs could falsely trigger the display of specific meeting details or IDs, leading to UI bugs or confusion.
+**Defense:** Explicitly test boundary conditions and unrecognized formats (sad paths) for components that perform pattern matching or parsing, ensuring the UI degrades gracefully or ignores invalid data instead of attempting to render it.

--- a/src/components/inputs/MeetingInput.test.tsx
+++ b/src/components/inputs/MeetingInput.test.tsx
@@ -68,4 +68,18 @@ describe('MeetingInput', () => {
     expect(screen.queryByText(/link detected/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Meeting ID:/i)).not.toBeInTheDocument();
   });
+
+  it('renders correctly with an unknown URL and does not show details', () => {
+    const data: MeetingData = { url: 'https://example.com/unknown-meeting' };
+    render(<MeetingInput data={data} onChange={mockOnChange} />);
+
+    expect(screen.getByText('Meeting Link')).toBeInTheDocument();
+
+    const input = screen.getByLabelText('Paste Meeting Link') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('https://example.com/unknown-meeting');
+
+    expect(screen.queryByText(/link detected/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Meeting ID:/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
🛑 **Vulnerability:** The `MeetingInput` component was missing a "Sad Path" test case. There was no coverage verifying how the UI behaves when an unrecognized or generic URL (like `https://example.com/unknown`) is pasted. Without this, there was a risk that regressions could cause the component to incorrectly display meeting detail sections or false positive IDs for non-meeting links.
🛡️ **Defense:** Added a specific test case in `src/components/inputs/MeetingInput.test.tsx` that provides an unknown URL and asserts that no service-specific meeting details or IDs are rendered in the DOM.
🔬 **Verification:** Run the specific test suite using `pnpm vitest run src/components/inputs/MeetingInput.test.tsx` or run the full suite using `pnpm test`.
📊 **Impact:** Increases test coverage for edge cases, eliminates fragility around URL parsing, and guarantees the UI degrades gracefully for unsupported inputs.

---
*PR created automatically by Jules for task [16491282563066802999](https://jules.google.com/task/16491282563066802999) started by @fderuiter*