### PR TITLE
🔦 Beacon: Add page-specific metadata for 404 error page

### DIFF
--- a/.jules/beacon.md
+++ b/.jules/beacon.md
@@ -1,0 +1,3 @@
+## 2025-04-29 - Fixed 404 Metadata Inheritance
+**Discovery:** The global metadata setup in Vike inherits the default title and description for 404 pages from the global config or Head component if not explicitly overridden.
+**Signal:** Added a `src/pages/_error/+config.ts` file to export a specific `title` and `description` to ensure the 404 page serves correct, descriptive metadata instead of the default global website metadata.

--- a/src/pages/_error/+config.ts
+++ b/src/pages/_error/+config.ts
@@ -1,0 +1,25 @@
+/*
+    QRCraftly
+    Copyright (C) 2025 fderuiter
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Page-specific configuration for the 404 Error page.
+ */
+export default {
+    title: '404 Page Not Found - QRCraftly',
+    description: 'The page you are looking for does not exist.'
+}


### PR DESCRIPTION
🕵️ **Discovery:** The 404 error page was inheriting the global application metadata (`QRCraftly - Free Custom QR Code Generator`) instead of displaying a descriptive title and description for the missing page.
🔦 **Signal:** Added a `src/pages/_error/+config.ts` configuration file that explicitly exports an accurate `title` and `description` to be injected into the `<head>` of the 404 page by Vike.
📈 **Impact:** Ensures search engines and social platforms receive proper metadata for error pages instead of misleading default content. It reinforces clear crawler signals for non-existent routes.
🔬 **Verification:** Verified by building the application (`pnpm build`) and confirming that `dist/client/404.html` contains the corrected `<title>` and `<meta name="description">` tags. Also verified that `pnpm test` continues to pass with no regressions.

---
*PR created automatically by Jules for task [10545079249013546372](https://jules.google.com/task/10545079249013546372) started by @fderuiter*