### PR TITLE
🔦 Beacon: Add explicit width and height to logo preview images

### DIFF
--- a/.jules/beacon.md
+++ b/.jules/beacon.md
@@ -1,3 +1,7 @@
 ## 2025-04-29 - Fixed 404 Metadata Inheritance
 **Discovery:** The global metadata setup in Vike inherits the default title and description for 404 pages from the global config or Head component if not explicitly overridden.
 **Signal:** Added a `src/pages/_error/+config.ts` file to export a specific `title` and `description` to ensure the 404 page serves correct, descriptive metadata instead of the default global website metadata.
+## 2025-04-30 - Add explicit width and height to images
+**Discovery:** Discovered that the logo and border logo preview `<img>` tags in `LogoControls.tsx` and `BorderControls.tsx` were missing explicit `width` and `height` attributes, which can cause Cumulative Layout Shift (CLS) when images load.
+**Signal:** Added explicit `width={48} height={48}` to the logo image (matching `w-12 h-12`) and `width={32} height={32}` to the border logo image (matching `w-8 h-8`).
+**Impact:** Improves Core Web Vitals (CLS) by reserving space for the images before they load, preventing layout shifts.

--- a/.jules/beacon.md
+++ b/.jules/beacon.md
@@ -1,7 +1,0 @@
-## 2025-04-29 - Fixed 404 Metadata Inheritance
-**Discovery:** The global metadata setup in Vike inherits the default title and description for 404 pages from the global config or Head component if not explicitly overridden.
-**Signal:** Added a `src/pages/_error/+config.ts` file to export a specific `title` and `description` to ensure the 404 page serves correct, descriptive metadata instead of the default global website metadata.
-## 2025-04-30 - Add explicit width and height to images
-**Discovery:** Discovered that the logo and border logo preview `<img>` tags in `LogoControls.tsx` and `BorderControls.tsx` were missing explicit `width` and `height` attributes, which can cause Cumulative Layout Shift (CLS) when images load.
-**Signal:** Added explicit `width={48} height={48}` to the logo image (matching `w-12 h-12`) and `width={32} height={32}` to the border logo image (matching `w-8 h-8`).
-**Impact:** Improves Core Web Vitals (CLS) by reserving space for the images before they load, preventing layout shifts.

--- a/src/components/style-controls/BorderControls.tsx
+++ b/src/components/style-controls/BorderControls.tsx
@@ -144,7 +144,7 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 {config.borderLogoUrl ? (
-                  <img src={config.borderLogoUrl} alt="Border Logo" className="w-8 h-8 object-contain bg-white rounded border border-slate-200" />
+                  <img src={config.borderLogoUrl} alt="Border Logo" width={32} height={32} className="w-8 h-8 object-contain bg-white rounded border border-slate-200" />
                 ) : (
                   <span className="text-xs text-slate-500 dark:text-slate-400 italic">No secondary logo</span>
                 )}

--- a/src/components/style-controls/LogoControls.tsx
+++ b/src/components/style-controls/LogoControls.tsx
@@ -58,7 +58,7 @@ export const LogoControls: React.FC<LogoControlsProps> = ({ config, onChange }) 
       ) : (
         <div className="bg-slate-50 dark:bg-slate-800/50 rounded-xl p-4 border border-slate-200 dark:border-slate-700 space-y-5">
           <div className="flex items-center gap-4">
-            <img src={config.logoUrl} alt="Logo" className="w-12 h-12 object-contain bg-white rounded-md border border-slate-200 shadow-sm" />
+            <img src={config.logoUrl} alt="Logo" width={48} height={48} className="w-12 h-12 object-contain bg-white rounded-md border border-slate-200 shadow-sm" />
             <div className="flex-1">
               <p className="text-sm font-medium text-slate-700 dark:text-slate-200">Custom Logo</p>
               <p className="text-xs text-slate-500 dark:text-slate-400">Embedded in center</p>


### PR DESCRIPTION
🕵️ **Discovery:** During a routine SEO scan, I identified that the custom logo and border logo preview `<img>` tags in `LogoControls.tsx` and `BorderControls.tsx` were missing explicit `width` and `height` attributes. Without these attributes, the browser cannot reserve the correct space for the image before it loads, leading to Cumulative Layout Shift (CLS).

🔦 **Signal:** Added explicit `width` and `height` attributes to the `<img>` tags that match their corresponding Tailwind CSS dimensions.
- `w-12 h-12` in `LogoControls.tsx` -> `width={48} height={48}`
- `w-8 h-8` in `BorderControls.tsx` -> `width={32} height={32}`

📈 **Impact:** Prevents Cumulative Layout Shift (CLS) when users upload custom logos or border logos, improving the Core Web Vitals score for layout stability.

🔬 **Verification:** The images render exactly as before due to the CSS classes, but inspecting the DOM confirms the `width` and `height` attributes are present. Checked against test suites and UI visual verifications successfully.

---
*PR created automatically by Jules for task [16656601040280365510](https://jules.google.com/task/16656601040280365510) started by @fderuiter*