### PR TITLE
🎨 Palette: [UX improvement] Add missing ARIA labels and focus states to BorderControls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2025-04-30 - Custom Control Groups Missing Labels
+
+**Learning:** When building complex inline custom control groups (like the `BorderControls.tsx` logo and text configurations), native `<label>` elements are often omitted for layout aesthetics. However, nested inputs and selects within these groups will lose their accessible name if explicit `aria-label`s are not provided, leading to a degraded screen reader experience. Icon-only buttons (like the X to clear a logo) are particularly prone to lacking `aria-label` and `focus-visible` states.
+**Action:** Always verify that every interactive element within a custom UI group has a distinct accessible name (via `aria-label` or `aria-labelledby`) and an explicit `focus-visible` styling for keyboard users, even if the parent container implies context visually.

--- a/src/components/style-controls/BorderControls.tsx
+++ b/src/components/style-controls/BorderControls.tsx
@@ -117,12 +117,14 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
                 placeholder="Text on border..."
                 value={config.borderText}
                 onChange={(e) => onChange({ borderText: e.target.value })}
+                aria-label="Border text"
                 className="w-full px-2 py-1.5 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded text-xs text-slate-700 dark:text-slate-200 focus:outline-none focus:border-teal-500"
               />
               <div className="flex gap-2">
                 <select
                   value={config.borderTextPosition || 'bottom-center'}
                   onChange={(e) => onChange({ borderTextPosition: e.target.value as BorderTextPosition })}
+                  aria-label="Border text position"
                   className="flex-1 px-2 py-1 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded text-xs text-slate-700 dark:text-slate-200 focus:outline-none focus:border-teal-500"
                 >
                   <option value="top-center">Top Center</option>
@@ -133,6 +135,7 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
                     type="color"
                     value={config.borderTextColor || '#ffffff'}
                     onChange={(e) => onChange({ borderTextColor: e.target.value })}
+                    aria-label="Border text color"
                     className="w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent"
                     title="Text Color"
                   />
@@ -149,14 +152,19 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
                   <span className="text-xs text-slate-500 dark:text-slate-400 italic">No secondary logo</span>
                 )}
                 {config.borderLogoUrl && (
-                  <button onClick={() => onChange({ borderLogoUrl: null })} className="text-xs text-rose-600 hover:underline">
+                  <button
+                    onClick={() => onChange({ borderLogoUrl: null })}
+                    aria-label="Remove border logo"
+                    title="Remove border logo"
+                    className="text-xs text-rose-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 rounded"
+                  >
                     <X className="w-3 h-3" />
                   </button>
                 )}
               </div>
               <button
                 onClick={() => borderLogoInputRef.current?.click()}
-                className="text-xs text-teal-600 dark:text-teal-400 hover:underline font-medium flex items-center gap-1"
+                className="text-xs text-teal-600 dark:text-teal-400 hover:underline font-medium flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 rounded px-1 py-0.5"
               >
                 <Upload className="w-3 h-3" />
                 {config.borderLogoUrl ? 'Change' : 'Add Logo'}
@@ -175,6 +183,7 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
                 <select
                   value={config.borderLogoPosition || 'bottom-center'}
                   onChange={(e) => onChange({ borderLogoPosition: e.target.value as BorderLogoPosition })}
+                  aria-label="Border logo position"
                   className="w-full px-2 py-1 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded text-xs text-slate-700 dark:text-slate-200 focus:outline-none focus:border-teal-500"
                 >
                   <option value="bottom-center">Bottom Center</option>


### PR DESCRIPTION
### 💡 What
Added missing `aria-label` attributes and `focus-visible` states to multiple inline controls within `BorderControls.tsx`:
- Border text input
- Border text position select
- Border text color input
- Border logo position select
- Icon-only "Remove border logo" button (also added a `title`)
- "Add Logo" / "Change Logo" button

### 🎯 Why
Custom control groups often omit native `<label>` elements for visual design reasons. This causes screen readers to lose context when navigating into these nested inputs and selects. Icon-only buttons are particularly susceptible to lacking accessible names and clear keyboard focus indicators. These small touches ensure all interactive elements remain fully usable and communicative to assistive technologies.

### 📸 Before/After
*(Visual changes are minimal, primarily consisting of correct focus rings when navigating via keyboard.)*

### ♿ Accessibility
- Ensured all input and select elements in the border configuration section have descriptive `aria-label`s.
- Ensured icon-only buttons have accessible names (`aria-label`) and tooltips (`title`).
- Restored standard keyboard focus outlines (`focus-visible:ring-2`) to previously unstyled interactive elements.

---
*PR created automatically by Jules for task [2995685056871300284](https://jules.google.com/task/2995685056871300284) started by @fderuiter*