### PR TITLE
🖋️ Scribe: document Playwright E2E tests

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,6 @@
+## 2024-05-15 - [Initial Scribe Journal Entry]
+**Insight:** Established Scribe journal.
+**Guideline:** Track critical learnings regarding documentation.
+## 2025-02-27 - [Missing Playwright Installation]
+**Insight:** Playwright E2E tests will fail with a confusing error message on fresh setups if `pnpm exec playwright install` is not run before `pnpm test:e2e`. This breaks the expected test onboarding path.
+**Guideline:** Ensure both unit tests (Vitest) and E2E tests (Playwright) are documented in the README along with their specific system/tool prerequisites.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pnpm preview
 
 ### Running Tests
 
-To run the test suite (Vitest):
+To run the unit test suite (Vitest):
 
 ```bash
 pnpm test
@@ -105,6 +105,14 @@ pnpm test
 To run coverage reports:
 ```bash
 pnpm test -- run --coverage
+```
+
+To run End-to-End (E2E) tests (Playwright):
+
+Note: On a fresh environment, you must install the required browsers first.
+```bash
+pnpm exec playwright install
+pnpm test:e2e
 ```
 
 ### Quality Assurance


### PR DESCRIPTION
💡 **What:** Added instructions to the `README.md` for running End-to-End (E2E) tests using Playwright. Also documented this missing path in the Scribe journal.
🎯 **Why:** The "Running Tests" section previously only documented unit tests (Vitest). A fresh environment needs the `pnpm exec playwright install` step to pass E2E tests, which was missing from the documentation.
🧠 **Cognitive Impact:** Fixes a broken testing onboarding path. New developers will no longer encounter confusing executable-not-found errors when trying to run the full suite.
📖 **Preview:** 
```markdown
To run End-to-End (E2E) tests (Playwright):

Note: On a fresh environment, you must install the required browsers first.
```bash
pnpm exec playwright install
pnpm test:e2e
```

---
*PR created automatically by Jules for task [546945691898002801](https://jules.google.com/task/546945691898002801) started by @fderuiter*