### PR TITLE
🎨 Palette: [UX improvement] Enhance BorderControls accessibility with aria-labels and focus states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-01 - Missing ARIA Labels in Complex Inline Form Groups
+**Learning:** Complex inline custom control groups (like logo position selections and nested text input configurations in `BorderControls`) frequently omit native `<label>` elements in favor of layout aesthetics. This breaks accessibility for screen reader users and keyboard navigation.
+**Action:** When working on form controls, especially those using Flexbox/Grid layouts where visual text labels are detached from inputs or replaced with placeholders, ensure explicit `aria-label` and `focus-visible` styling are added to maintain accessibility.

--- a/src/components/style-controls/BorderControls.tsx
+++ b/src/components/style-controls/BorderControls.tsx
@@ -118,12 +118,14 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
                 value={config.borderText}
                 onChange={(e) => onChange({ borderText: e.target.value })}
                 className="w-full px-2 py-1.5 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded text-xs text-slate-700 dark:text-slate-200 focus:outline-none focus:border-teal-500"
+                aria-label="Border text"
               />
               <div className="flex gap-2">
                 <select
                   value={config.borderTextPosition || 'bottom-center'}
                   onChange={(e) => onChange({ borderTextPosition: e.target.value as BorderTextPosition })}
                   className="flex-1 px-2 py-1 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded text-xs text-slate-700 dark:text-slate-200 focus:outline-none focus:border-teal-500"
+                  aria-label="Border text position"
                 >
                   <option value="top-center">Top Center</option>
                   <option value="bottom-center">Bottom Center</option>
@@ -133,8 +135,9 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
                     type="color"
                     value={config.borderTextColor || '#ffffff'}
                     onChange={(e) => onChange({ borderTextColor: e.target.value })}
-                    className="w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent"
+                    className="w-6 h-6 rounded cursor-pointer border-0 p-0 bg-transparent focus-visible:ring-2 focus-visible:ring-teal-500 focus:outline-none focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800"
                     title="Text Color"
+                    aria-label="Border text color"
                   />
                 </div>
               </div>
@@ -149,14 +152,18 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
                   <span className="text-xs text-slate-500 dark:text-slate-400 italic">No secondary logo</span>
                 )}
                 {config.borderLogoUrl && (
-                  <button onClick={() => onChange({ borderLogoUrl: null })} className="text-xs text-rose-600 hover:underline">
+                  <button
+                    onClick={() => onChange({ borderLogoUrl: null })}
+                    className="text-xs text-rose-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 rounded focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800"
+                    aria-label="Remove border logo"
+                  >
                     <X className="w-3 h-3" />
                   </button>
                 )}
               </div>
               <button
                 onClick={() => borderLogoInputRef.current?.click()}
-                className="text-xs text-teal-600 dark:text-teal-400 hover:underline font-medium flex items-center gap-1"
+                className="text-xs text-teal-600 dark:text-teal-400 hover:underline font-medium flex items-center gap-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 rounded focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800"
               >
                 <Upload className="w-3 h-3" />
                 {config.borderLogoUrl ? 'Change' : 'Add Logo'}
@@ -176,6 +183,7 @@ export const BorderControls: React.FC<BorderControlsProps> = ({ config, onChange
                   value={config.borderLogoPosition || 'bottom-center'}
                   onChange={(e) => onChange({ borderLogoPosition: e.target.value as BorderLogoPosition })}
                   className="w-full px-2 py-1 bg-white dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded text-xs text-slate-700 dark:text-slate-200 focus:outline-none focus:border-teal-500"
+                  aria-label="Border logo position"
                 >
                   <option value="bottom-center">Bottom Center</option>
                   <option value="bottom-right">Bottom Right</option>


### PR DESCRIPTION
**💡 What:** 
Added semantic `aria-label` attributes to the various input fields and select menus within `BorderControls.tsx` that previously lacked accessible names. Added `focus-visible` styling (`focus-visible:ring-2`, `focus-visible:ring-teal-500`, etc.) to the color input, logo upload button, and remove logo button. Also added a `.jules/palette.md` journal entry.

**🎯 Why:**
Complex inline form groups often omit native `<label>` elements for layout purposes, causing screen readers to announce "unlabelled edit text" or similar, making the form inaccessible. Additionally, keyboard navigation lacked clear visual focus indicators on some interactive elements, making it difficult for users who rely on keyboard navigation to know which element had focus.

**📸 Before/After:**
- **Before:** The border text input, position dropdowns, color input, and logo buttons were effectively invisible to screen readers without context, and keyboard focus states were inconsistent or missing.
- **After:** All elements now have clear accessible names via `aria-label`, and navigating with the `Tab` key shows distinct teal (or rose for the remove button) focus rings around the active elements.

**♿ Accessibility:**
- Added `aria-label="Border text"` to text input.
- Added `aria-label="Border text position"` and `aria-label="Border logo position"` to selects.
- Added `aria-label="Border text color"` to the `<input type="color">`.
- Added `aria-label="Remove border logo"` to the icon-only `<button>`.
- Added `focus-visible` utility classes to interactive elements that lacked them.

---
*PR created automatically by Jules for task [13604379581516087783](https://jules.google.com/task/13604379581516087783) started by @fderuiter*