### PR TITLE
🛡️ Shield: [test improvement] Add Sad Path testing for Phone generator

### DIFF
--- a/src/utils/qrHelpers_SadPaths.test.ts
+++ b/src/utils/qrHelpers_SadPaths.test.ts
@@ -22,9 +22,10 @@ import {
   constructEmailString,
   constructVCardString,
   constructPaymentString,
-  constructSmsString
+  constructSmsString,
+  constructPhoneString
 } from './qrHelpers';
-import { EmailData, VCardData, PaymentData, CryptoNetwork, SmsData } from '../types';
+import { EmailData, VCardData, PaymentData, CryptoNetwork, SmsData, PhoneData } from '../types';
 
 describe('QR Helpers Sad Paths', () => {
   describe('escapeVCardString', () => {
@@ -139,6 +140,24 @@ describe('QR Helpers Sad Paths', () => {
       expect(result).not.toMatch(/\?.*\?/);
       // With strict whitelist, 'bodyinjected' is removed
       expect(result).toBe('sms:123?body=hello');
+    });
+  });
+
+  describe('constructPhoneString', () => {
+    it('should strip malicious parameter injections', () => {
+      const data: PhoneData = {
+        number: '123?body=injected'
+      };
+      const result = constructPhoneString(data);
+      expect(result).toBe('tel:123');
+    });
+
+    it('should handle empty input', () => {
+      const data: PhoneData = {
+        number: ''
+      };
+      const result = constructPhoneString(data);
+      expect(result).toBe('tel:');
     });
   });
 });


### PR DESCRIPTION
* 🛑 **Vulnerability:** The `constructPhoneString` function handles potentially malicious phone input strings, but its sad path and edge case behavior (like URL parameter injection and empty values) lacked explicit test coverage in `src/utils/qrHelpers_SadPaths.test.ts`.
* 🛡️ **Defense:** Added robust test cases specifically verifying that `constructPhoneString` securely strips malicious parameter injections (e.g. `123?body=injected`) and correctly returns a minimal safe URI (`tel:`) for empty string inputs.
* 🔬 **Verification:** Verify the new defenses with `npx vitest run src/utils/qrHelpers_SadPaths.test.ts` or via the full test suite (`pnpm test`).
* 📊 **Impact:** Provides explicit regression protection against boundary conditions in the phone QR generator, improving test suite confidence.

---
*PR created automatically by Jules for task [15782586876779999968](https://jules.google.com/task/15782586876779999968) started by @fderuiter*