### PR TITLE
🎨 Palette: Improve keyboard accessibility on native color and range inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Improve Keyboard Accessibility on Native Inputs
+**Learning:** Native input elements like `<input type="color">` and `<input type="range">` might not have obvious focus rings in all browsers when interacted with via keyboard, or they may lack consistency with the app's design system. Relying purely on browser defaults can sometimes cause reduced accessibility for keyboard users, particularly when custom styles or transparent backgrounds are used.
+**Action:** Always ensure that native form inputs receive explicit `focus-visible` utility classes (e.g., `focus-visible:ring-2`, `focus-visible:ring-offset-1`) so they provide clear and consistent visual feedback during keyboard navigation.

--- a/src/components/ui/ColorInput.tsx
+++ b/src/components/ui/ColorInput.tsx
@@ -78,13 +78,13 @@ export const ColorInput: React.FC<ColorInputProps> = ({
             type="color"
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            className={`${sizeClass} rounded cursor-pointer border-0 p-0 bg-transparent`}
+            className={`${sizeClass} rounded cursor-pointer border-0 p-0 bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-900`}
           />
           <input
             type="text"
             value={textValue}
             onChange={handleTextChange}
-            className="text-xs text-slate-600 dark:text-slate-300 font-mono bg-transparent border border-transparent hover:border-slate-300 focus:border-teal-500 rounded px-1 py-0.5 w-24 outline-none transition-colors"
+            className="text-xs text-slate-600 dark:text-slate-300 font-mono bg-transparent border border-transparent hover:border-slate-300 focus:border-teal-500 rounded px-1 py-0.5 w-24 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-900"
             aria-label={`${label} Hex Code`}
           />
       </div>

--- a/src/components/ui/RangeInput.tsx
+++ b/src/components/ui/RangeInput.tsx
@@ -42,7 +42,7 @@ export const RangeInput: React.FC<RangeInputProps> = ({
       value={value}
       aria-valuetext={formatValue(value)}
       onChange={(e) => onChange(parseFloat(e.target.value))}
-      className="w-full accent-teal-700 dark:accent-teal-500 cursor-pointer"
+      className="w-full accent-teal-700 dark:accent-teal-500 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 rounded-lg"
     />
   </div>
 );


### PR DESCRIPTION
💡 What: Added explicit `focus-visible` Tailwind classes to `<input type="color">`, `<input type="text">` inside `ColorInput.tsx`, and to `<input type="range">` in `RangeInput.tsx`.
🎯 Why: Native inputs often rely on default browser focus rings which can be inconsistent or invisible when custom styling/transparent backgrounds are applied, creating a poor keyboard navigation experience.
📸 Before/After: Visual outline was missing or inconsistent when tabbing; now a clear teal ring appears consistently.
♿ Accessibility: Improved clear visual feedback for keyboard users navigating the color and range inputs.

---
*PR created automatically by Jules for task [16165176949190018428](https://jules.google.com/task/16165176949190018428) started by @fderuiter*