### PR TITLE
🔨 Forge: Form Fields Component Composition

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Component Composition for Form Field Layouts
+**Context:** Form input components (`TextField`, `TextAreaField`, `SelectField`) were duplicating container layout, `<label>` rendering, and conditional `<CharCount>` logic, leading to inconsistencies and visual drift.
+**Decision:** Extracted a shared `FieldWrapper` component to handle the cross-cutting concerns (container, labels, character counting) using component composition (passing the actual input element as `children`).
+**Consequence:** Layout logic is strictly localized to `FieldWrapper`. New input components only need to concern themselves with their specific interactive element, reducing boilerplate and risk of accessibility omissions (like missing labels).

--- a/src/components/inputs/FormFields.tsx
+++ b/src/components/inputs/FormFields.tsx
@@ -21,6 +21,37 @@ const getLabelClass = (size: FieldSize, customClass?: string) => {
   return "block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1";
 };
 
+interface FieldWrapperProps extends BaseFieldProps {
+  children: React.ReactNode;
+  showCharCount?: boolean;
+  maxLength?: number;
+  currentLength?: number;
+}
+
+const FieldWrapper: React.FC<FieldWrapperProps> = ({
+  label,
+  id,
+  fieldSize = "xs",
+  className,
+  labelClassName,
+  children,
+  showCharCount,
+  maxLength,
+  currentLength = 0,
+}) => {
+  return (
+    <div className={className}>
+      <label htmlFor={id} className={getLabelClass(fieldSize, labelClassName)}>
+        {label}
+      </label>
+      {children}
+      {showCharCount && maxLength && (
+        <CharCount current={currentLength} max={maxLength} />
+      )}
+    </div>
+  );
+};
+
 // Omit 'size' to prevent conflict, and 'id' to ensure our required 'id' overrides the optional one cleanly (though TS usually handles required overriding optional, explicit omit is safer for strict configs)
 interface TextFieldProps
   extends
@@ -53,10 +84,16 @@ export const TextField: React.FC<TextFieldProps> = ({
     : type;
 
   return (
-    <div className={className}>
-      <label htmlFor={id} className={getLabelClass(fieldSize, labelClassName)}>
-        {label}
-      </label>
+    <FieldWrapper
+      label={label}
+      id={id}
+      fieldSize={fieldSize}
+      className={className}
+      labelClassName={labelClassName}
+      showCharCount={showCharCount}
+      maxLength={maxLength}
+      currentLength={String(value || "").length}
+    >
       <div className={showPasswordToggle ? "relative" : ""}>
         <input
           id={id}
@@ -81,10 +118,7 @@ export const TextField: React.FC<TextFieldProps> = ({
           </button>
         )}
       </div>
-      {showCharCount && maxLength && (
-        <CharCount current={String(value || "").length} max={maxLength} />
-      )}
-    </div>
+    </FieldWrapper>
   );
 };
 
@@ -107,10 +141,16 @@ export const TextAreaField: React.FC<TextAreaFieldProps> = ({
   ...props
 }) => {
   return (
-    <div className={className}>
-      <label htmlFor={id} className={getLabelClass(fieldSize, labelClassName)}>
-        {label}
-      </label>
+    <FieldWrapper
+      label={label}
+      id={id}
+      fieldSize={fieldSize}
+      className={className}
+      labelClassName={labelClassName}
+      showCharCount={showCharCount}
+      maxLength={maxLength}
+      currentLength={String(value || "").length}
+    >
       <textarea
         id={id}
         maxLength={maxLength}
@@ -118,10 +158,7 @@ export const TextAreaField: React.FC<TextAreaFieldProps> = ({
         value={value}
         {...props}
       />
-      {showCharCount && maxLength && (
-        <CharCount current={String(value || "").length} max={maxLength} />
-      )}
-    </div>
+    </FieldWrapper>
   );
 };
 
@@ -141,13 +178,16 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   ...props
 }) => {
   return (
-    <div className={className}>
-      <label htmlFor={id} className={getLabelClass(fieldSize, labelClassName)}>
-        {label}
-      </label>
+    <FieldWrapper
+      label={label}
+      id={id}
+      fieldSize={fieldSize}
+      className={className}
+      labelClassName={labelClassName}
+    >
       <select id={id} className={SELECT_CLASSES} {...props}>
         {children}
       </select>
-    </div>
+    </FieldWrapper>
   );
 };


### PR DESCRIPTION
🛑 **The Smell:** `TextField`, `TextAreaField`, and `SelectField` components in `src/components/inputs/FormFields.tsx` were duplicating the same `<label>` rendering, container `<div>`, and conditional `<CharCount>` logic. This redundancy increased boilerplate, created potential for visual drift, and cluttered the specific interactive element's logic.

🔨 **The Fix:** Extracted a shared `FieldWrapper` component to handle the cross-cutting concerns (container, labels, character counting) using component composition (passing the actual input element as `children`). Refactored the field components to use this wrapper. Journaled the architectural decision in `.jules/forge.md`.

🧠 **The Why:** Reduces component size and isolates layout logic. New input components only need to concern themselves with their specific interactive element, reducing boilerplate and risk of accessibility omissions (like missing labels). Adheres to AHA/DRY principles by standardizing structure.

⚠️ **Risk:** Low - pure refactor, types passed, no behavior changed.

---
*PR created automatically by Jules for task [8860767095554752979](https://jules.google.com/task/8860767095554752979) started by @fderuiter*