### PR TITLE
🛟 Beacon: Add Open Graph image tags to home page

### DIFF
--- a/src/pages/index/+config.ts
+++ b/src/pages/index/+config.ts
@@ -23,5 +23,7 @@
  */
 export default {
     title: 'QRCraftly - Free Custom QR Code Generator',
-    description: 'Generate beautiful, custom QR codes for free. No sign-up required. Secure, client-side generation.'
+    description: 'Generate beautiful, custom QR codes for free. No sign-up required. Secure, client-side generation.',
+    image: '/og-image.png',
+    imageAlt: 'QRCraftly - Free Custom QR Code Generator Preview'
 }


### PR DESCRIPTION
**Discovery:**
The root application page (`src/pages/index/+config.ts`) was missing explicit Open Graph image configuration. While the default `HeadDefault` component provides a fallback, explicitly declaring this configuration is standard practice within this app and guarantees that Open Graph properties for the highest-traffic page are not left to framework defaults, which improves consistency across the site.

**Signal:**
Added explicit `image` (`/og-image.png`) and `imageAlt` configuration properties to the home page's Vike configuration file (`src/pages/index/+config.ts`).

**Impact:**
Explicitly defines the image metadata used for Open Graph tags, ensuring that when the application is shared via social platforms, the generated preview correctly presents the intended preview image and accessibility alternate text as the "first impression." 

**Verification:**
- Ran `pnpm build` to verify the application continues to build correctly.
- Ran `pnpm test` and `pnpm test:e2e` to verify no regressions were introduced.
- Evaluated `src/layouts/Head.tsx` to verify the values propagate correctly via `pageContext`.

---
*PR created automatically by Jules for task [5627565279167266765](https://jules.google.com/task/5627565279167266765) started by @fderuiter*