### PR TITLE
🎨 Palette: Add focus-visible styling to native range and color inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-04 - Native form input keyboard accessibility
+**Learning:** Browsers often suppress or obscure default focus outlines on native form inputs like `<input type="color">` and `<input type="range">`. Relying on default browser behavior for these specific input types leads to poor keyboard navigation as users cannot tell which element has focus.
+**Action:** Always apply explicit `focus-visible` styling (e.g., `focus-visible:ring-2 focus-visible:ring-offset-1`) using Tailwind utility classes to native input types like `range` and `color` to ensure a consistent, accessible experience for keyboard users across browsers.

--- a/src/components/ui/ColorInput.tsx
+++ b/src/components/ui/ColorInput.tsx
@@ -78,7 +78,7 @@ export const ColorInput: React.FC<ColorInputProps> = ({
             type="color"
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            className={`${sizeClass} rounded cursor-pointer border-0 p-0 bg-transparent`}
+            className={`${sizeClass} rounded cursor-pointer border-0 p-0 bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-900`}
           />
           <input
             type="text"

--- a/src/components/ui/RangeInput.tsx
+++ b/src/components/ui/RangeInput.tsx
@@ -42,7 +42,7 @@ export const RangeInput: React.FC<RangeInputProps> = ({
       value={value}
       aria-valuetext={formatValue(value)}
       onChange={(e) => onChange(parseFloat(e.target.value))}
-      className="w-full accent-teal-700 dark:accent-teal-500 cursor-pointer"
+      className="w-full accent-teal-700 dark:accent-teal-500 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-900 rounded-lg"
     />
   </div>
 );


### PR DESCRIPTION
**💡 What:** Added explicit `focus-visible` Tailwind classes to the native `<input type="color">` and `<input type="range">` elements in the `ColorInput` and `RangeInput` components. Also created a `palette.md` journal entry detailing this pattern.

**🎯 Why:** Browsers frequently suppress or poorly render default focus outlines on these specific native input types, particularly when custom-styled or transparent. This makes it very difficult for keyboard users to know when these elements are focused, breaking navigation intuitiveness.

**📸 Before/After:**
*Before:* Pressing Tab to reach a color or range input provided no clear visual indication of focus.
*After:* Pressing Tab provides a clear teal focus ring (`focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-1`).

**♿ Accessibility:** Greatly improves keyboard navigation and compliance with WCAG 2.4.7 Focus Visible by ensuring all interactive elements have a clear, highly visible focus state when navigated via keyboard.

---
*PR created automatically by Jules for task [6360376526832075693](https://jules.google.com/task/6360376526832075693) started by @fderuiter*