### PR TITLE
🎨 Palette: Add Copy to Clipboard feature for generated QR code

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Visual Feedback for Clipboard Actions
+**Learning:** Adding a "Copy Image" button for the generated QR code significantly improves the interaction flow by eliminating the need to save a file locally just to paste it elsewhere. Furthermore, providing immediate visual feedback (such as temporarily changing the copy icon to a checkmark) builds confidence and reduces user frustration from uncertain clipboard writes.
+**Action:** Whenever implementing a clipboard copy feature, always include a visual confirmation state (like a temporary checkmark icon and updated aria-label) that lasts for a few seconds.

--- a/src/components/QRTool.tsx
+++ b/src/components/QRTool.tsx
@@ -21,7 +21,7 @@ import { QRConfig } from '@/types';
 import { DEFAULT_CONFIG } from '@/constants';
 import InputPanel from '@/components/InputPanel';
 import QRCanvas from '@/components/QRCanvas';
-import { Download, Share2, QrCode, ChevronDown, Camera, Moon, Sun, Info } from 'lucide-react';
+import { Download, Share2, QrCode, ChevronDown, Camera, Moon, Sun, Info, Copy, Check } from 'lucide-react';
 import { useDebounce, useOnClickOutside } from '@/utils/hooks';
 import { useQRDownload } from '@/utils/useQRDownload';
 
@@ -46,7 +46,8 @@ export default function QRTool({ initialConfig, title }: { initialConfig?: Parti
   const qrRef = useRef<HTMLDivElement>(null);
   const downloadMenuRef = useRef<HTMLDivElement>(null);
 
-  const { downloadToDevice: hookDownload, handleSaveAs: hookSaveAs, handleSaveSvg: hookSaveSvg, handleShare } = useQRDownload(qrRef, config);
+  const { downloadToDevice: hookDownload, handleSaveAs: hookSaveAs, handleSaveSvg: hookSaveSvg, handleShare, handleCopy } = useQRDownload(qrRef, config);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     setIsMounted(true);
@@ -59,6 +60,14 @@ export default function QRTool({ initialConfig, title }: { initialConfig?: Parti
   // Debounce the config for QRCanvas to prevent lag during rapid typing or style changes.
   // 100ms is a good balance between responsiveness and performance.
   const debouncedConfig = useDebounce(config, 100);
+
+  const onCopy = async () => {
+    const success = await handleCopy();
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
 
   /**
    * Updates the QR configuration state.
@@ -230,6 +239,15 @@ export default function QRTool({ initialConfig, title }: { initialConfig?: Parti
                           )}
                        </div>
                        
+                       <button
+                          onClick={onCopy}
+                          className="flex items-center justify-center w-12 bg-teal-50 dark:bg-slate-800 border border-teal-200 dark:border-slate-700 text-teal-700 dark:text-teal-400 rounded-xl font-medium hover:bg-teal-100 dark:hover:bg-slate-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
+                          title="Copy Image"
+                          aria-label={copied ? "Copied to clipboard" : "Copy QR code to clipboard"}
+                       >
+                          {copied ? <Check className="w-5 h-5 text-emerald-500" /> : <Copy className="w-5 h-5" />}
+                       </button>
+
                        <button 
                           onClick={handleShare}
                           className="flex items-center justify-center w-12 bg-teal-50 dark:bg-slate-800 border border-teal-200 dark:border-slate-700 text-teal-700 dark:text-teal-400 rounded-xl font-medium hover:bg-teal-100 dark:hover:bg-slate-700 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"

--- a/src/utils/useQRDownload.ts
+++ b/src/utils/useQRDownload.ts
@@ -28,10 +28,11 @@ interface UseQRDownloadReturn {
   handleSaveAs: (format: 'png' | 'jpeg' | 'webp') => Promise<void>;
   handleSaveSvg: () => Promise<void>;
   handleShare: () => Promise<void>;
+  handleCopy: () => Promise<boolean>;
 }
 
 /**
- * Hook to handle downloading and sharing of the QR code.
+ * Hook to handle downloading, sharing, and copying of the QR code.
  * Extracts this logic from the main component to reduce cognitive load.
  *
  * @param qrRef Reference to the container element containing the canvas.
@@ -130,6 +131,32 @@ export function useQRDownload(
    * Uses the Web Share API to share the QR code image directly to other apps.
    * Falls back to downloading if sharing is not supported.
    */
+  /**
+   * Copies the QR code image directly to the clipboard.
+   * @returns A boolean indicating if the copy operation was successful.
+   */
+  const handleCopy = useCallback(async (): Promise<boolean> => {
+    const canvas = qrRef.current?.querySelector('canvas');
+    if (!canvas) return false;
+
+    try {
+      const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'));
+      if (!blob) return false;
+
+      // Note: ClipboardItem is not supported in all browsers, but works in modern ones
+      // We check for ClipboardItem to avoid throwing errors on older devices
+      if (typeof ClipboardItem !== 'undefined') {
+        const item = new ClipboardItem({ 'image/png': blob });
+        await navigator.clipboard.write([item]);
+        return true;
+      }
+      return false;
+    } catch (err) {
+      console.warn('Failed to copy to clipboard:', err);
+      return false;
+    }
+  }, [qrRef]);
+
   const handleShare = useCallback(async () => {
     const canvas = qrRef.current?.querySelector('canvas');
     if (canvas) {
@@ -178,5 +205,5 @@ export function useQRDownload(
     }
   }, [config, getFilename]);
 
-  return { downloadToDevice, handleSaveAs, handleSaveSvg, handleShare };
+  return { downloadToDevice, handleSaveAs, handleSaveSvg, handleShare, handleCopy };
 }


### PR DESCRIPTION
## 💡 What
Added a "Copy Image" button alongside the "Share" button that allows users to copy the generated QR code directly to their clipboard as a PNG image.

## 🎯 Why
Eliminates the friction of forcing users to download the QR code image just to paste it into another application, significantly improving the user experience for the most common use case. Visual feedback (checkmark icon + updated ARIA label) builds confidence and confirms the action.

## 📸 Before/After
N/A - the button appears directly adjacent to the Share button.

## ♿ Accessibility
The copy button includes an `aria-label` that dynamically updates from "Copy QR code to clipboard" to "Copied to clipboard" when successful. It also uses explicit `title` attributes and standard focus-visible styles.

---
*PR created automatically by Jules for task [3032593053586248621](https://jules.google.com/task/3032593053586248621) started by @fderuiter*