### PR TITLE
🛡️ Shield: [test improvement/fix] Fix unhandled promise rejection in SVG export

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,0 +1,5 @@
+## 2025-02-12 - Unhandled Promise Rejections in try/catch
+
+**Discovery:** Returning `new Promise(...)` directly from inside a `try/catch` block allows asynchronous promise rejections (like a `FileReader` throwing an error) to completely bypass the local `catch` handler, causing an unhandled rejection that escapes the function boundary.
+
+**Defense:** When wrapping a dynamically created Promise with a `try/catch` intended to handle its errors, you must explicitly `await` the Promise (e.g. `return await new Promise(...)`). Additionally, tests simulating such errors must restore any mocked globals (like `fetch` or `FileReader`) inside a `try/finally` block to prevent test pollution if assertions fail.

--- a/src/utils/svgExport.test.ts
+++ b/src/utils/svgExport.test.ts
@@ -114,6 +114,42 @@ describe('generateQRSvg', () => {
     expect(svg).toContain('data:image/png;base64,iVBORw0KGgo=');
   });
 
+  it('falls back to original url if FileReader fails', async () => {
+    const originalFileReader = global.FileReader;
+    const originalFetch = global.fetch;
+
+    try {
+      // Create a mock FileReader that immediately triggers onerror
+      class MockFileReader {
+        onload: any = null;
+        onerror: any = null;
+        readAsDataURL() {
+          if (this.onerror) {
+            this.onerror(new Error('Mocked FileReader error'));
+          }
+        }
+      }
+
+      global.FileReader = MockFileReader as any;
+      global.fetch = vi.fn().mockResolvedValue({
+        blob: vi.fn().mockResolvedValue(new Blob(['fake data'])),
+      });
+
+      const config: QRConfig = {
+        ...DEFAULT_CONFIG as QRConfig,
+        logoUrl: 'http://example.com/logo.png',
+      };
+
+      const svg = await generateQRSvg(config);
+
+      expect(svg).toContain('<image');
+      expect(svg).toContain('href="http://example.com/logo.png"');
+    } finally {
+      global.FileReader = originalFileReader;
+      global.fetch = originalFetch;
+    }
+  });
+
   it('gracefully handles an empty value string', async () => {
     // qrcode.create() throws for empty input; generateQRSvg should not crash
     const config = { ...DEFAULT_CONFIG, value: '' } as QRConfig;

--- a/src/utils/svgExport.ts
+++ b/src/utils/svgExport.ts
@@ -34,7 +34,7 @@ async function toDataUrl(url: string): Promise<string> {
   try {
     const response = await fetch(url, { mode: 'cors' });
     const blob = await response.blob();
-    return new Promise<string>((resolve, reject) => {
+    return await new Promise<string>((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => resolve(reader.result as string);
       reader.onerror = () => reject(new Error('FileReader error'));


### PR DESCRIPTION
**Vulnerability:**
In `src/utils/svgExport.ts`, the `toDataUrl` function creates a `new Promise` for the `FileReader` inside a `try/catch` block, but failed to `await` it. As a result, if `FileReader` encountered an error (e.g., throwing `FileReader error`), the rejection bypassed the local `catch` block entirely. This caused an unhandled promise rejection to bubble up, bypassing the intended fallback of returning the original URL, which could crash or break the caller's fallback mechanism.

**Defense:**
1. Modified `toDataUrl` to explicitly `return await new Promise(...)`, ensuring any `reject` calls are properly caught by the `catch` block.
2. Added a robust "Sad Path" test case in `src/utils/svgExport.test.ts` to simulate a `FileReader` error and assert that the function correctly falls back to returning the original URL. The test uses a `try...finally` block to safely mock and restore `global.FileReader` and `global.fetch`, preventing test pollution.

**Verification:**
Run `pnpm test src/utils/svgExport.test.ts` to verify the new test passes, and `pnpm test` to confirm the entire suite remains green.

**Impact:**
Increases code confidence by properly sealing an error boundary in the SVG export logic. Eliminates a potential source of unhandled promise rejections and silent failures in production, whilst also increasing test coverage for sad paths.

---
*PR created automatically by Jules for task [4156649544401309660](https://jules.google.com/task/4156649544401309660) started by @fderuiter*