### PR TITLE
🛡️ Shield: [test improvement/fix] Fix unhandled promise rejection in toDataUrl fallback

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,0 +1,5 @@
+## 2025-05-06 - Unawaited Promise inside try/catch
+
+**Discovery:** When returning a `Promise` from within a `try/catch` block, if the promise is not awaited (`return new Promise(...)`), any rejection inside that promise skips the local `catch` block. This leads to an unhandled promise rejection and prevents fallback mechanisms from firing, creating a silent failure.
+
+**Defense:** Always use `return await new Promise(...)` when creating and returning a promise inside a `try/catch` block so that asynchronous rejections are properly caught and handled by the surrounding logic. Added a specific test mimicking a FileReader `.onerror` event to enforce the fallback behavior.

--- a/src/utils/svgExport.test.ts
+++ b/src/utils/svgExport.test.ts
@@ -152,4 +152,40 @@ describe('generateQRSvg', () => {
     const svg = await generateQRSvg(config);
     expect(svg).toContain('My Headline');
   });
+
+  it('falls back to the original URL if FileReader fails to read blob', async () => {
+    // Mock fetch to successfully return a blob
+    const originalFetch = global.fetch;
+    global.fetch = vi.fn().mockResolvedValue({
+      blob: () => Promise.resolve(new Blob(['fake data'])),
+    } as any);
+
+    // Mock FileReader to fail when readAsDataURL is called
+    const originalFileReader = global.FileReader;
+    class MockFileReader {
+      onerror: () => void = () => {};
+      readAsDataURL() {
+        setTimeout(() => this.onerror(), 0);
+      }
+    }
+    global.FileReader = MockFileReader as any;
+
+    try {
+      const config: QRConfig = {
+        ...(DEFAULT_CONFIG as QRConfig),
+        logoUrl: 'https://example.com/fail-logo.png',
+      };
+
+      const svg = await generateQRSvg(config);
+
+      // Because we added `await` to the new Promise in toDataUrl,
+      // the error should be caught by the try/catch,
+      // and it should gracefully fall back to the external URL.
+      expect(svg).toContain('<image');
+      expect(svg).toContain('https://example.com/fail-logo.png');
+    } finally {
+      global.FileReader = originalFileReader;
+      global.fetch = originalFetch;
+    }
+  });
 });

--- a/src/utils/svgExport.ts
+++ b/src/utils/svgExport.ts
@@ -34,7 +34,7 @@ async function toDataUrl(url: string): Promise<string> {
   try {
     const response = await fetch(url, { mode: 'cors' });
     const blob = await response.blob();
-    return new Promise<string>((resolve, reject) => {
+    return await new Promise<string>((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => resolve(reader.result as string);
       reader.onerror = () => reject(new Error('FileReader error'));


### PR DESCRIPTION
**Vulnerability:**
The `toDataUrl` function in `src/utils/svgExport.ts` attempts to fetch a URL and then create a `FileReader` object to read it as a Data URL. This entire sequence is wrapped in a `try/catch`. However, the function returns a `new Promise` without explicitly `await`ing it. As a result, if the `FileReader` encountered an error and called `reject`, the promise rejection would bypass the local `catch` block entirely. This causes an Unhandled Promise Rejection, breaking the intended graceful fallback behavior (which is supposed to return the original URL if the conversion fails).

**Defense:**
1. Modified `toDataUrl` to use `return await new Promise(...)`. This ensures the Promise is resolved/rejected within the context of the `try/catch` block, allowing the `catch` block to properly intercept failures.
2. Added a robust deterministic test in `src/utils/svgExport.test.ts` that safely mocks `global.fetch` and `global.FileReader` to simulate an `.onerror` event, verifying the `catch` block fires and the fallback URL is inserted into the resulting SVG.
3. Created a `.jules/shield.md` journal entry to document the risk of unawaited promises inside `try/catch` blocks.

**Verification:**
Run the new unit test directly using `npx vitest --run src/utils/svgExport.test.ts`.

**Impact:**
Increases code confidence by eliminating a silent failure pattern. Ensures robust, self-contained SVG generation fallback logic works deterministically under external load failures.

---
*PR created automatically by Jules for task [10043977856100076108](https://jules.google.com/task/10043977856100076108) started by @fderuiter*