### PR TITLE
⚡ Bolt: [performance improvement] Pre-calculate spatial grids correctly with section-splitting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - Pre-calculate spatial grids correctly with section-splitting
+**Learning:** In 2D grid rendering operations where performance is sensitive (like in QR code drawing with complex neighboring dependencies such as `QRStyle.CIRCUIT`), flat looping across all `x` and `y` while applying multiple `if` conditions (e.g., `isEye`) incurs significant overhead.
+**Action:** When pre-calculating spatial grids, apply 'section-splitting' to loop independently around known dead zones (like corner eye markers) instead of running conditional checks inside a flat loop. Also, use pre-calculated 1D array index offsets instead of redundant row/col math to speed up neighborhood checks.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,11 @@
+1. **Apply section-splitting to `validGrid` in `src/utils/qr-renderers/modules.ts`**
+   - In `getModuleDrawer` for `QRStyle.CIRCUIT`, `validGrid` currently iterates over all rows and columns and calls `isEye` inside the loop.
+   - Refactor the loop into three sections (Top, Middle, Bottom) to skip eye corners (Top-Left, Top-Right, Bottom-Left).
+   - Remove the `isEye` check inside the loop.
+2. **Create/Update `.jules/bolt.md`**
+   - Add a journal entry explaining the learning: pre-calculating spatial grids using section-splitting to skip known dead zones.
+3. **Pre-commit step**
+   - Run `pre_commit_instructions` to ensure proper testing, verification, review, and reflection are done.
+4. **Submit PR**
+   - Title: `⚡ Bolt: [performance improvement]`
+   - Follow Bolt's format for the description.

--- a/src/utils/qr-renderers/modules.ts
+++ b/src/utils/qr-renderers/modules.ts
@@ -1,6 +1,6 @@
 import { QRConfig, QRStyle, QRModules } from '../../types';
 import { drawRoundRect, drawRoughRect } from '../canvasHelpers';
-import { isEye, getIsCoveredByLogo, LogoMetrics } from './utils';
+import { getIsCoveredByLogo, LogoMetrics } from './utils';
 
 type DrawModuleFn = (r: number, c: number, x: number, y: number, cx: number, cy: number) => void;
 
@@ -34,14 +34,37 @@ const getModuleDrawer = (
         case QRStyle.CIRCUIT: {
             // Pre-calculate valid modules for CIRCUIT style to avoid repeated expensive checks
             // (isCoveredByLogo and isEye) for every neighbor of every module.
+            // Optimization: Apply section-splitting to skip known dead zones like corner eye markers entirely
+            // instead of running conditional checks inside flat loops.
             const validGrid = new Uint8Array(moduleCount * moduleCount);
-            for (let r = 0; r < moduleCount; r++) {
-                for (let c = 0; c < moduleCount; c++) {
-                    if (modules.get(r, c) && !isEye(r, c, moduleCount) && !isCoveredByLogo(r, c)) {
-                        validGrid[r * moduleCount + c] = 1;
-                    }
+
+            const markValid = (r: number, c: number) => {
+                if (modules.get(r, c) && !isCoveredByLogo(r, c)) {
+                    validGrid[r * moduleCount + c] = 1;
+                }
+            };
+
+            // Top Section (Rows 0-6): Skip TL (0-6) and TR (size-7 to size-1)
+            for (let r = 0; r < 7; r++) {
+                for (let c = 7; c < moduleCount - 7; c++) {
+                    markValid(r, c);
                 }
             }
+
+            // Middle Section (Rows 7 to size-8): No eyes
+            for (let r = 7; r < moduleCount - 7; r++) {
+                for (let c = 0; c < moduleCount; c++) {
+                    markValid(r, c);
+                }
+            }
+
+            // Bottom Section (Rows size-7 to size-1): Skip BL (0-6)
+            for (let r = moduleCount - 7; r < moduleCount; r++) {
+                for (let c = 7; c < moduleCount; c++) {
+                    markValid(r, c);
+                }
+            }
+
             // Pre-calculate dimensional constants
             const rCircuit = cellSize * 0.1;
             const thickness = cellSize * 0.4;
@@ -49,10 +72,13 @@ const getModuleDrawer = (
             const linkLen = cellSize / 2 + 1;
 
             return (r, c, x, y, cx, cy) => {
-                const hasTop = r > 0 && validGrid[(r-1) * moduleCount + c];
-                const hasBottom = r < moduleCount-1 && validGrid[(r+1) * moduleCount + c];
-                const hasLeft = c > 0 && validGrid[r * moduleCount + (c-1)];
-                const hasRight = c < moduleCount-1 && validGrid[r * moduleCount + (c+1)];
+                // Optimization: Use flat 1D indexing and pre-calculated offsets to avoid redundant multiplications
+                const idx = r * moduleCount + c;
+
+                const hasTop = r > 0 && validGrid[idx - moduleCount];
+                const hasBottom = r < moduleCount - 1 && validGrid[idx + moduleCount];
+                const hasLeft = c > 0 && validGrid[idx - 1];
+                const hasRight = c < moduleCount - 1 && validGrid[idx + 1];
 
                 // Full square with very tiny notches
                 drawRoundRect(ctx, x, y, cellSize, cellSize, rCircuit);


### PR DESCRIPTION
### 💡 What
Optimized the spatial grid (`validGrid`) pre-calculation and inner loop neighbor checking for `QRStyle.CIRCUIT` in `src/utils/qr-renderers/modules.ts`.
- Removed redundant `isEye()` checks by applying "section-splitting" which correctly limits the looping boundaries to omit corner eye blocks entirely.
- Switched neighboring offset math (e.g. `(r+1) * moduleCount + c`) to use pre-calculated 1D `idx` values.
- Cleaned up the unused `isEye` helper import.

### 🎯 Why
In complex QR styles like `CIRCUIT`, module rendering is highly dependent on neighboring modules. Calculating this state cleanly meant performing `moduleCount * moduleCount` iterations across the grid. Since corner eyes (7x7 blocks in the Top-Left, Top-Right, Bottom-Left) are standard dead zones where modules aren't drawn by this routine, skipping them inherently speeds up the matrix initialization phase. Similarly, multiplying row/col inside the tight drawing closure adds small but recurring overhead. 

### 📊 Impact
- The initialization loop saves checking 147 dead modules (`7*7 * 3` regions) on standard minimum QR sizes (21x21).
- Vitest benchmarks for other rendering modules (HIVE/STARBURST) show standard execution. While there isn't an explicit benchmark for `CIRCUIT` alone, skipping the matrix dead-zones mathematically drops roughly ~33% of the flat loop's overhead, and the 1D indexing improves the nested closure call logic per-module.

### 🔬 Measurement
All rendering and E2E tests have passed successfully. Tested that the output canvas logic remains fully unchanged when applying the Circuit style.

---
*PR created automatically by Jules for task [2643518084779699248](https://jules.google.com/task/2643518084779699248) started by @fderuiter*