### PR TITLE
🔦 Beacon: Add semantic HTML navigation to Type Selector

### DIFF
--- a/src/components/inputs/TypeSelector.tsx
+++ b/src/components/inputs/TypeSelector.tsx
@@ -36,9 +36,10 @@ export const TypeSelector: React.FC<TypeSelectorProps> = ({
   onSelect,
 }) => {
   return (
-    <div className="grid grid-cols-4 gap-2 p-2 bg-slate-100 dark:bg-slate-800 rounded-xl transition-colors duration-300">
-      {[
-        { type: QRType.URL, icon: Link, label: "URL" },
+    <nav aria-label="QR Code Types">
+      <ul className="grid grid-cols-4 gap-2 p-2 bg-slate-100 dark:bg-slate-800 rounded-xl transition-colors duration-300">
+        {[
+          { type: QRType.URL, icon: Link, label: "URL" },
         { type: QRType.TEXT, icon: Type, label: "Text" },
         { type: QRType.WIFI, icon: Wifi, label: "WiFi" },
         { type: QRType.EVENT, icon: Calendar, label: "Event" },
@@ -49,47 +50,50 @@ export const TypeSelector: React.FC<TypeSelectorProps> = ({
         { type: QRType.PAYMENT, icon: CreditCard, label: "Payment" },
         { type: QRType.LOCATION, icon: MapPin, label: "Location" },
         { type: QRType.MEETING, icon: Video, label: "Meeting" },
-        { type: QRType.SOCIAL, icon: Share2, label: "Social" },
-      ].map((item) => {
-        const route = TYPE_ROUTES[item.type];
-        const isActive = currentType === item.type;
-        const className = `flex flex-col items-center justify-center gap-1 px-2 py-2 rounded-lg text-xs font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 ${
+          { type: QRType.SOCIAL, icon: Share2, label: "Social" },
+        ].map((item) => {
+          const route = TYPE_ROUTES[item.type];
+          const isActive = currentType === item.type;
+          const className = `flex flex-col w-full items-center justify-center gap-1 px-2 py-2 rounded-lg text-xs font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-800 ${
           isActive
             ? "bg-white dark:bg-slate-700 text-teal-700 dark:text-teal-400 shadow-sm"
             : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-200/50 dark:hover:bg-slate-700/50"
         }`;
 
-        if (route) {
-          return (
-            <a
-              key={item.type}
-              href={route}
-              onClick={() => onSelect(item.type)}
-              aria-current={isActive ? "page" : undefined}
-              className={className}
-            >
-              <item.icon className="w-4 h-4" />
-              <span className="truncate w-full text-center text-slate-700 dark:text-slate-200">
-                {item.label}
-              </span>
-            </a>
-          );
-        }
+          if (route) {
+            return (
+              <li key={item.type}>
+                <a
+                  href={route}
+                  onClick={() => onSelect(item.type)}
+                  aria-current={isActive ? "page" : undefined}
+                  className={className}
+                >
+                  <item.icon className="w-4 h-4" />
+                  <span className="truncate w-full text-center text-slate-700 dark:text-slate-200">
+                    {item.label}
+                  </span>
+                </a>
+              </li>
+            );
+          }
 
-        return (
-          <button
-            key={item.type}
-            onClick={() => onSelect(item.type)}
-            aria-pressed={isActive}
-            className={className}
-          >
-            <item.icon className="w-4 h-4" />
-            <span className="truncate w-full text-center text-slate-700 dark:text-slate-200">
-              {item.label}
-            </span>
-          </button>
-        );
-      })}
-    </div>
+          return (
+            <li key={item.type}>
+              <button
+                onClick={() => onSelect(item.type)}
+                aria-pressed={isActive}
+                className={className}
+              >
+                <item.icon className="w-4 h-4" />
+                <span className="truncate w-full text-center text-slate-700 dark:text-slate-200">
+                  {item.label}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
   );
 };


### PR DESCRIPTION
🕵️ **Discovery:** The QR Type Selector (`src/components/inputs/TypeSelector.tsx`) was using a generic `<div>` with `grid` classes to render its list of links and buttons. This flat "div soup" structure misses an opportunity to communicate the relationship between these items to search engine crawlers and screen readers.

🔦 **Signal:** Refactored the `<div>` wrapper into a semantic `<nav aria-label="QR Code Types">` containing a proper `<ul>` and `<li>` structure. 

📈 **Impact:** Improves technical SEO by providing semantic meaning to the primary navigation structure of the tool, helping search engine bots better understand and crawl the different available QR code generators (URL, Text, WiFi, etc.).

🔬 **Verification:** 
1. Run `pnpm test` to ensure no rendering tests were broken.
2. Inspect the rendered DOM of the Type Selector component to confirm it is now a `<nav>` with a `<ul>` and `<li>` items.

---
*PR created automatically by Jules for task [7802079807051953385](https://jules.google.com/task/7802079807051953385) started by @fderuiter*