### PR TITLE
🎨 Palette: Add ARIA labels to configuration buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-07 - ARIA labels for Icon/Visual Buttons
+**Learning:** When using custom icon or visual buttons mapped from an array (like logo border styles or error correction levels), standard text might be omitted or purely visual. Testing library errors explicitly surface missing accessible names.
+**Action:** Ensure dynamically mapped custom toggle buttons include an explicit `aria-label` incorporating the dynamic label text (e.g. `Set ${feature} to ${label}`) so screen readers can interpret the action without relying on generic element content.

--- a/src/components/StyleControls.test.tsx
+++ b/src/components/StyleControls.test.tsx
@@ -176,11 +176,11 @@ describe('StyleControls Component', () => {
       const logoConfig = { ...DEFAULT_CONFIG, logoUrl: 'data:image/png;base64,fake', logoPaddingStyle: 'square' as LogoPaddingStyle };
       render(<StyleControls config={logoConfig} onChange={mockOnChange} />);
 
-      const circleBtn = screen.getByRole('button', { name: 'Circle' });
+      const circleBtn = screen.getByRole('button', { name: 'Set logo border style to Circle' });
       await user.click(circleBtn);
       expect(mockOnChange).toHaveBeenCalledWith({ logoPaddingStyle: 'circle' });
 
-      const noneBtn = screen.getByRole('button', { name: 'None' });
+      const noneBtn = screen.getByRole('button', { name: 'Set logo border style to None' });
       await user.click(noneBtn);
       expect(mockOnChange).toHaveBeenCalledWith({ logoPaddingStyle: 'none' });
   });

--- a/src/components/style-controls/AdvancedControls.tsx
+++ b/src/components/style-controls/AdvancedControls.tsx
@@ -45,6 +45,7 @@ export const AdvancedControls: React.FC<AdvancedControlsProps> = ({ config, onCh
                   key={level.id}
                   onClick={() => onChange({ errorCorrectionLevel: level.id })}
                   aria-pressed={config.errorCorrectionLevel === level.id}
+                  aria-label={`Set error correction level to ${level.label}`}
                   className={`p-2 rounded-lg text-left border transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-900 ${
                     config.errorCorrectionLevel === level.id
                       ? 'border-teal-500 bg-teal-50 dark:bg-teal-900/30 text-teal-900 dark:text-teal-200'

--- a/src/components/style-controls/LogoControls.tsx
+++ b/src/components/style-controls/LogoControls.tsx
@@ -69,6 +69,7 @@ export const LogoControls: React.FC<LogoControlsProps> = ({ config, onChange }) 
                   key={style.id}
                   onClick={() => onChange({ logoPaddingStyle: style.id as LogoPaddingStyle })}
                   aria-pressed={config.logoPaddingStyle === style.id}
+                  aria-label={`Set logo border style to ${style.label}`}
                   className={`flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-md text-xs font-medium transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-slate-800 ${
                     config.logoPaddingStyle === style.id
                       ? 'bg-teal-100 dark:bg-teal-900/30 text-teal-700 dark:text-teal-400'


### PR DESCRIPTION
### 💡 What
Added descriptive `aria-label` attributes to the dynamically mapped custom configuration buttons, specifically for the Error Correction Level toggles and Logo Border Style toggles. Also updated the corresponding test queries.

### 🎯 Why
These buttons either contained purely visual elements (like icons and shapes) or text that lacked context out-of-flow (like just saying "Circle" or "Low"). Providing a clear `aria-label` (e.g. "Set error correction level to Low (~7%)") allows screen reader users to understand the explicit purpose and effect of clicking the toggle.

### 📸 Before/After
*Before:* Buttons lacked context for screen readers.
*After:* Buttons announce their specific action via their `aria-label` property.

### ♿ Accessibility
Improves keyboard navigation and screen reader support for the advanced controls and logo setting sections by clearly describing the actionable elements.

---
*PR created automatically by Jules for task [1328557747352295489](https://jules.google.com/task/1328557747352295489) started by @fderuiter*