### PR TITLE
✏️ Scribe: [documentation/README improvement] Add Playwright Troubleshooting to README

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,3 @@
+## 2025-05-07 - Playwright E2E Test Runner Configuration
+**Insight:** The Playwright configuration hardcodes `npm run dev` for its webServer command, which can cause the tests to hang indefinitely if the local environment strictly uses `pnpm` and lacks `npm`.
+**Guideline:** Document this limitation in the `README.md` Troubleshooting section so users know to either ensure `npm` is available or manually start `pnpm dev` before running `pnpm test:e2e`.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ Lighthouse CI runs on every Pull Request to audit performance, accessibility, be
 
 ## Troubleshooting
 
+### Playwright E2E tests fail to start or hang
+
+The Playwright configuration (`playwright.config.ts`) currently hardcodes `npm run dev` to start the local development server. If you strictly use `pnpm` and do not have `npm` installed (or your environment blocks it), the tests will hang waiting for the server to start.
+
+**Solution:**
+Ensure `npm` is available in your path, or manually start the development server using `pnpm dev` in a separate terminal before running `pnpm test:e2e`.
+
 ### `pnpm install` fails with `gyp ERR!` or `Package cairo was not found`
 
 This usually happens because `node-canvas` (a development dependency used for testing) requires system-level libraries to be installed.


### PR DESCRIPTION
💡 **What:** Added a troubleshooting section in the README explaining how to circumvent a situation where Playwright e2e tests hang when `npm` is not installed or available.
🎯 **Why:** Playwright's `webServer` config hardcodes `npm run dev`. This repository strictly enforces `pnpm`. If a developer uses a pure `pnpm` environment, `pnpm test:e2e` will hang indefinitely waiting for the dev server.
🧠 **Cognitive Impact:** Fixes a broken onboarding path where new contributors would be stumped by test commands that appear broken.
📖 **Preview:** 
```markdown
### Playwright E2E tests fail to start or hang

The Playwright configuration (`playwright.config.ts`) currently hardcodes `npm run dev` to start the local development server. If you strictly use `pnpm` and do not have `npm` installed (or your environment blocks it), the tests will hang waiting for the server to start.

**Solution:**
Ensure `npm` is available in your path, or manually start the development server using `pnpm dev` in a separate terminal before running `pnpm test:e2e`.
```

---
*PR created automatically by Jules for task [5952431947020214229](https://jules.google.com/task/5952431947020214229) started by @fderuiter*