### PR TITLE
🧹 Polish: Extract CheckboxField component

### DIFF
--- a/.jules/polish.md
+++ b/.jules/polish.md
@@ -1,0 +1,3 @@
+## 2025-03-09 - Extract Form Checkbox
+**Smell:** Raw inline `<input type="checkbox">` elements scattered across form components, repeating styling logic and deviating from the established `FieldWrapper` pattern used by text and select inputs.
+**Remedy:** Extracted a reusable `CheckboxField` component into `src/components/inputs/FormFields.tsx` to DRY out form checkbox styling and structure.

--- a/src/components/inputs/FormFields.tsx
+++ b/src/components/inputs/FormFields.tsx
@@ -191,3 +191,34 @@ export const SelectField: React.FC<SelectFieldProps> = ({
     </FieldWrapper>
   );
 };
+
+interface CheckboxFieldProps
+  extends
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, "id" | "type">,
+    BaseFieldProps {}
+
+export const CheckboxField: React.FC<CheckboxFieldProps> = ({
+  label,
+  id,
+  fieldSize = "xs",
+  className,
+  labelClassName,
+  ...props
+}) => {
+  return (
+    <div className={className}>
+      <label
+        htmlFor={id}
+        className={`flex items-center gap-2 cursor-pointer ${getLabelClass(fieldSize, labelClassName).replace('mb-1', '')} ${fieldSize === 'xs' ? 'font-sans' : ''}`}
+      >
+        <input
+          id={id}
+          type="checkbox"
+          className="rounded text-teal-700 dark:text-teal-600 focus:ring-teal-500 border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900"
+          {...props}
+        />
+        <span>{label}</span>
+      </label>
+    </div>
+  );
+};

--- a/src/components/inputs/WifiInput.tsx
+++ b/src/components/inputs/WifiInput.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { WifiData, WifiEncryption } from "../../types";
-import { TextField, SelectField } from "./FormFields";
+import { TextField, SelectField, CheckboxField } from "./FormFields";
 
 interface WifiInputProps {
   data: WifiData;
@@ -67,23 +67,13 @@ export const WifiInput: React.FC<WifiInputProps> = ({ data, onChange }) => {
         />
       )}
 
-      <div className="flex items-center pt-2">
-        <label
-          htmlFor="wifi-hidden"
-          className="flex items-center gap-2 cursor-pointer"
-        >
-          <input
-            id="wifi-hidden"
-            type="checkbox"
-            checked={data.hidden}
-            onChange={(e) => onChange({ hidden: e.target.checked })}
-            className="rounded text-teal-700 dark:text-teal-600 focus:ring-teal-500 border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900"
-          />
-          <span className="text-sm text-slate-600 dark:text-slate-400 font-sans">
-            Hidden Network
-          </span>
-        </label>
-      </div>
+      <CheckboxField
+        id="wifi-hidden"
+        label="Hidden Network"
+        checked={data.hidden}
+        onChange={(e) => onChange({ hidden: e.target.checked })}
+        className="pt-2"
+      />
     </div>
   );
 };


### PR DESCRIPTION
💩 **Smell:** Inline, duplicated `<input type="checkbox">` logic in `WifiInput.tsx` that didn't follow the centralized pattern used for text and select fields in `FormFields.tsx`.

✨ **Polish:** Extracted a reusable `CheckboxField` component into `FormFields.tsx` to standardize checkbox styling and structure.

📉 **Reduction:** Removed duplicated inline styling from `WifiInput.tsx`, centralizing the checkbox UI pattern.

🛡️ **Safety:** Verified with full test suite - NO LOGIC CHANGES. Tests pass perfectly.

---
*PR created automatically by Jules for task [1347307637314501757](https://jules.google.com/task/1347307637314501757) started by @fderuiter*