### PR TITLE
🛡️ Shield: [test improvement/fix] Add clipboard API test coverage

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,0 +1,3 @@
+## 2025-02-21 - Missing Test Coverage for Clipboard API Integration
+**Discovery:** The `handleCopy` function in `useQRDownload.ts` lacked test coverage. It relied on `navigator.clipboard.write` and `ClipboardItem`, which might fail silently or throw errors across different browser environments without proper coverage.
+**Defense:** Added test cases testing `handleCopy` when `ClipboardItem` is available and when it throws, ensuring fallback behaviors and error handling are robust.

--- a/src/utils/useQRDownload.test.ts
+++ b/src/utils/useQRDownload.test.ts
@@ -169,4 +169,81 @@ describe('useQRDownload', () => {
     expect(removeSpy).toHaveBeenCalledWith(link);
     expect(global.URL.revokeObjectURL).toHaveBeenCalled();
   });
+
+  describe('handleCopy', () => {
+    let originalClipboardItem: any;
+    let originalClipboard: any;
+
+    beforeEach(() => {
+      originalClipboardItem = (global as any).ClipboardItem;
+      originalClipboard = global.navigator.clipboard;
+    });
+
+    afterEach(() => {
+      (global as any).ClipboardItem = originalClipboardItem;
+      Object.defineProperty(global.navigator, 'clipboard', {
+        value: originalClipboard,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('copies to clipboard when supported', async () => {
+      const mockWrite = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(global.navigator, 'clipboard', {
+        value: { write: mockWrite },
+        writable: true,
+        configurable: true,
+      });
+
+      const MockClipboardItem = vi.fn().mockImplementation(function(this: any, data) { this.data = data; });
+      (global as any).ClipboardItem = MockClipboardItem;
+
+      const { result } = renderHook(() => useQRDownload(mockQrRef, DEFAULT_CONFIG as QRConfig));
+
+      const success = await result.current.handleCopy();
+
+      expect(success).toBe(true);
+      expect(mockCanvas.toBlob).toHaveBeenCalled();
+      expect(MockClipboardItem).toHaveBeenCalledWith(expect.objectContaining({ 'image/png': expect.any(Blob) }));
+      expect(mockWrite).toHaveBeenCalled();
+    });
+
+    it('returns false if canvas is not found', async () => {
+      const emptyRef = { current: { querySelector: vi.fn(() => null) } } as any;
+      const { result } = renderHook(() => useQRDownload(emptyRef, DEFAULT_CONFIG as QRConfig));
+
+      const success = await result.current.handleCopy();
+      expect(success).toBe(false);
+    });
+
+    it('returns false if ClipboardItem is not supported', async () => {
+      (global as any).ClipboardItem = undefined;
+      const { result } = renderHook(() => useQRDownload(mockQrRef, DEFAULT_CONFIG as QRConfig));
+
+      const success = await result.current.handleCopy();
+      expect(success).toBe(false);
+    });
+
+    it('returns false and logs warning if write fails', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const mockWrite = vi.fn().mockRejectedValue(new Error('Clipboard error'));
+      Object.defineProperty(global.navigator, 'clipboard', {
+        value: { write: mockWrite },
+        writable: true,
+        configurable: true,
+      });
+
+      const MockClipboardItem = vi.fn().mockImplementation(function(this: any, data) { this.data = data; });
+      (global as any).ClipboardItem = MockClipboardItem;
+
+      const { result } = renderHook(() => useQRDownload(mockQrRef, DEFAULT_CONFIG as QRConfig));
+
+      const success = await result.current.handleCopy();
+
+      expect(success).toBe(false);
+      expect(consoleWarnSpy).toHaveBeenCalledWith('Failed to copy to clipboard:', expect.any(Error));
+    });
+  });
+
 });


### PR DESCRIPTION
🛑 **Vulnerability:** The `handleCopy` function within `useQRDownload.ts` lacked test coverage. This function interacts with potentially flaky browser APIs (`navigator.clipboard.write` and `ClipboardItem`) which can behave unpredictably across different environments, leading to silent failures or unhandled rejections without robust testing.

🛡️ **Defense:** Added a comprehensive `describe` block testing the `handleCopy` function. The tests include explicit mocks for `navigator.clipboard` and `ClipboardItem`, validating:
- The Happy Path (successful generation and copying of a blob).
- The Missing Canvas case (graceful failure).
- The Unsupported API case (graceful failure when `ClipboardItem` is undefined).
- The Error case (catching and warning when `clipboard.write` rejects).

🔬 **Verification:**
You can run this specific test file in isolation to verify the defenses:
```bash
pnpm vitest run src/utils/useQRDownload.test.ts
```

📊 **Impact:** Increases test coverage for a critical feature and increases code confidence by establishing a testing pattern for complex browser APIs.

---
*PR created automatically by Jules for task [15120058063139394957](https://jules.google.com/task/15120058063139394957) started by @fderuiter*