### PR TITLE
🛡️ Shield: Fix setTimeout test flakiness in svgExport.test.ts

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,0 +1,3 @@
+## 2025-05-09 - [Test Flakiness - setTimeout in tests]
+**Discovery:** Found a test `falls back to the original URL if FileReader fails to read blob` in `src/utils/svgExport.test.ts` using `setTimeout` which is a known source of test flakiness, making the test asynchronous and non-deterministic.
+**Defense:** Replace `setTimeout` with synchronous triggering of the mocked event (e.g. `this.onerror()`) or use proper Promise resolution to ensure deterministic execution of the test.

--- a/src/utils/svgExport.test.ts
+++ b/src/utils/svgExport.test.ts
@@ -201,7 +201,7 @@ describe('generateQRSvg', () => {
     class MockFileReader {
       onerror: () => void = () => {};
       readAsDataURL() {
-        setTimeout(() => this.onerror(), 0);
+        this.onerror();
       }
     }
     global.FileReader = MockFileReader as any;


### PR DESCRIPTION
🛑 **Vulnerability:** The test `falls back to the original URL if FileReader fails to read blob` in `src/utils/svgExport.test.ts` utilized `setTimeout` within its `MockFileReader` implementation. This asynchronous execution introduces race conditions and potential flakiness into the test suite, making test results non-deterministic.
🛡️ **Defense:** Replaced the `setTimeout` call with a direct, synchronous invocation of `this.onerror()`. This guarantees the mocked error triggers deterministically during the test execution flow. Added the learning to the `.jules/shield.md` journal.
🔬 **Verification:** Run `pnpm test` to verify the full suite passes, or specifically `pnpm test src/utils/svgExport.test.ts` to execute the modified file.
📊 **Impact:** Fixes a potential source of test flakiness, improving CI reliability and confidence in the test suite.

---
*PR created automatically by Jules for task [2669943327316340128](https://jules.google.com/task/2669943327316340128) started by @fderuiter*