### PR TITLE
🔨 Forge: [Refactor PatternModule rendering strategy]

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,0 +1,4 @@
+## 2026-05-10 - [Extract Method: Component Render logic]
+**Context:**  The PatternModule component used a series of `if` statements for rendering SVG patterns or simple styled `div`s. This is hard to maintain, not easily extensible, and increases cyclomatic complexity.
+**Decision:** We are using a strategy pattern utilizing a dictionary of render functions to render specific component pattern modules.
+**Consequence:** Enhances extensibility, simplifies the `PatternModule` component implementation, and makes it OCP (Open-Closed Principle) compliant.

--- a/src/components/ui/PatternModule.tsx
+++ b/src/components/ui/PatternModule.tsx
@@ -1,57 +1,44 @@
 import React from 'react';
 import { QRStyle } from '../../types';
 
+const patternRenderers: Record<QRStyle, React.FC> = {
+  [QRStyle.STARBURST]: () => (
+    <div className="flex items-center justify-center">
+      <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+      </svg>
+    </div>
+  ),
+  [QRStyle.HIVE]: () => (
+    <div className="flex items-center justify-center">
+      <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
+        <polygon points="50,0 100,25 100,75 50,100 0,75 0,25" />
+      </svg>
+    </div>
+  ),
+  [QRStyle.SWISS]: () => <div className="bg-current rounded-full" />,
+  [QRStyle.MODERN]: () => <div className="bg-current rounded-sm" />,
+  [QRStyle.FLUID]: () => <div className="bg-current rounded-full" />,
+  [QRStyle.CIRCUIT]: () => (
+    <div className="relative w-full h-full bg-transparent flex items-center justify-center">
+      <div className="w-1.5 h-1.5 bg-current rounded-full" />
+      <div className="absolute inset-0 border border-current opacity-50" />
+    </div>
+  ),
+  [QRStyle.GRUNGE]: () => (
+    <div className="flex items-center justify-center">
+      <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
+        <polygon points="10,0 100,10 90,100 0,90" />
+      </svg>
+    </div>
+  ),
+  [QRStyle.STANDARD]: () => <div className="bg-current" />,
+};
+
 /**
  * Helper component for rendering pattern preview modules.
  */
 export const PatternModule: React.FC<{ style: QRStyle }> = ({ style }) => {
-  if (style === QRStyle.STARBURST) {
-    return (
-      <div className="flex items-center justify-center">
-        <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
-          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-        </svg>
-      </div>
-    );
-  }
-  if (style === QRStyle.HIVE) {
-    // Hexagon
-    return (
-      <div className="flex items-center justify-center">
-        <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
-          <polygon points="50,0 100,25 100,75 50,100 0,75 0,25" />
-        </svg>
-      </div>
-    );
-  }
-  if (style === QRStyle.SWISS) {
-    return <div className="bg-current rounded-full" />;
-  }
-  if (style === QRStyle.MODERN) {
-    return <div className="bg-current rounded-sm" />;
-  }
-  if (style === QRStyle.FLUID) {
-    return <div className="bg-current rounded-full" />;
-  }
-  if (style === QRStyle.CIRCUIT) {
-    return (
-      <div className="relative w-full h-full bg-transparent flex items-center justify-center">
-        <div className="w-1.5 h-1.5 bg-current rounded-full" />
-        <div className="absolute inset-0 border border-current opacity-50" />
-      </div>
-    );
-  }
-  if (style === QRStyle.GRUNGE) {
-    return (
-      <div className="flex items-center justify-center">
-        <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
-          <polygon points="10,0 100,10 90,100 0,90" />
-        </svg>
-      </div>
-    );
-  }
-  // Standard and others
-  return (
-    <div className="bg-current" />
-  );
+  const Renderer = patternRenderers[style] || patternRenderers[QRStyle.STANDARD];
+  return <Renderer />;
 };


### PR DESCRIPTION
🛑 **The Smell:** 
The `PatternModule` component in `src/components/ui/PatternModule.tsx` relied on a sequential series of `if` statements to render the preview pattern modules for different `QRStyle`s. This was hard to read, had high cyclomatic complexity, and required touching the main render loop every time a new style was added (violating the Open-Closed Principle).

🔨 **The Fix:** 
Introduced a `patternRenderers` mapping dictionary using the Strategy Pattern to map `QRStyle` enum keys directly to their respective rendering React functional components.

🧠 **The Why:** 
Reduces the cognitive load of the component and strictly decouples the rendering logic for individual patterns from the control logic of the component, making the code cleaner and highly extensible for future styles.

⚠️ **Risk:** 
Low - pure structural refactor. Type checker and tests passed successfully, and fallback states to `QRStyle.STANDARD` are explicitly handled.

---
*PR created automatically by Jules for task [13593984811394174684](https://jules.google.com/task/13593984811394174684) started by @fderuiter*