### PR TITLE
🎨 Palette: Add placeholders to text inputs for better UX

### DIFF
--- a/src/components/inputs/EmailInput.tsx
+++ b/src/components/inputs/EmailInput.tsx
@@ -16,6 +16,7 @@ export const EmailInput: React.FC<EmailInputProps> = ({ data, onChange }) => {
         label="Email Address"
         autoComplete="email"
         type="email"
+        placeholder="name@example.com"
         maxLength={254}
         value={data.email}
         onChange={(e) => onChange({ email: e.target.value })}
@@ -24,6 +25,7 @@ export const EmailInput: React.FC<EmailInputProps> = ({ data, onChange }) => {
         id="email-subject"
         label="Subject"
         type="text"
+        placeholder="e.g. Invitation"
         maxLength={200}
         value={data.subject}
         onChange={(e) => onChange({ subject: e.target.value })}
@@ -33,6 +35,7 @@ export const EmailInput: React.FC<EmailInputProps> = ({ data, onChange }) => {
         id="email-body"
         label="Body"
         rows={3}
+        placeholder="Write your message here..."
         maxLength={2000}
         value={data.body}
         onChange={(e) => onChange({ body: e.target.value })}

--- a/src/components/inputs/EventInput.tsx
+++ b/src/components/inputs/EventInput.tsx
@@ -14,6 +14,7 @@ export const EventInput: React.FC<EventInputProps> = ({ data, onChange }) => {
         id="event-title"
         label="Event Title"
         type="text"
+        placeholder="e.g. Birthday Party"
         maxLength={200}
         value={data.title}
         onChange={(e) => onChange({ title: e.target.value })}
@@ -37,6 +38,7 @@ export const EventInput: React.FC<EventInputProps> = ({ data, onChange }) => {
         id="event-location"
         label="Location"
         type="text"
+        placeholder="e.g. 123 Main St, City"
         maxLength={300}
         value={data.location}
         onChange={(e) => onChange({ location: e.target.value })}
@@ -46,6 +48,7 @@ export const EventInput: React.FC<EventInputProps> = ({ data, onChange }) => {
         id="event-description"
         label="Description"
         rows={3}
+        placeholder="Event details..."
         maxLength={2000}
         value={data.description}
         onChange={(e) => onChange({ description: e.target.value })}

--- a/src/components/inputs/WifiInput.tsx
+++ b/src/components/inputs/WifiInput.tsx
@@ -17,6 +17,7 @@ export const WifiInput: React.FC<WifiInputProps> = ({ data, onChange }) => {
         id="wifi-ssid"
         label="Network Name (SSID)"
         type="text"
+        placeholder="e.g. MyHomeNetwork"
         maxLength={32}
         value={data.ssid}
         onChange={(e) => onChange({ ssid: e.target.value })}
@@ -46,6 +47,7 @@ export const WifiInput: React.FC<WifiInputProps> = ({ data, onChange }) => {
           id="wifi-identity"
           label="Identity / Username"
           type="text"
+          placeholder="e.g. user@domain.com"
           maxLength={128}
           value={data.eapIdentity}
           onChange={(e) => onChange({ eapIdentity: e.target.value })}
@@ -59,6 +61,7 @@ export const WifiInput: React.FC<WifiInputProps> = ({ data, onChange }) => {
           label="Password"
           autoComplete="off"
           type="password"
+          placeholder="Network password"
           maxLength={63}
           value={data.password}
           onChange={(e) => onChange({ password: e.target.value })}


### PR DESCRIPTION
💡 What: Added placeholder text to `EmailInput`, `WifiInput`, and `EventInput` fields.
🎯 Why: To provide helpful context and examples for users, improving form intuitiveness and guiding them on expected data formatting.
📸 Before/After: Inputs previously lacked placeholders. They now display examples like "name@example.com", "e.g. MyHomeNetwork", and "e.g. Birthday Party".
♿ Accessibility: Improved cognitive accessibility by making expected input formats clearer.

---
*PR created automatically by Jules for task [11618204259360184329](https://jules.google.com/task/11618204259360184329) started by @fderuiter*