### PR TITLE
🖋️ Scribe: [documentation/README improvement]

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,3 @@
+## 2026-05-10 - Fix Playwright config for pnpm
+**Insight:** The Playwright configuration hardcoded `npm run dev` for the web server, which fails for users who strictly use `pnpm`.
+**Guideline:** Always use the project's native package manager (e.g., `pnpm run dev`) in configuration files (like `playwright.config.ts`) instead of hardcoding `npm`, and ensure documentation matches the required tooling.

--- a/README.md
+++ b/README.md
@@ -143,13 +143,6 @@ Lighthouse CI runs on every Pull Request to audit performance, accessibility, be
 
 ## Troubleshooting
 
-### Playwright E2E tests fail to start or hang
-
-The Playwright configuration (`playwright.config.ts`) currently hardcodes `npm run dev` to start the local development server. If you strictly use `pnpm` and do not have `npm` installed (or your environment blocks it), the tests will hang waiting for the server to start.
-
-**Solution:**
-Ensure `npm` is available in your path, or manually start the development server using `pnpm dev` in a separate terminal before running `pnpm test:e2e`.
-
 ### `pnpm install` fails with `gyp ERR!` or `Package cairo was not found`
 
 This usually happens because `node-canvas` (a development dependency used for testing) requires system-level libraries to be installed.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
   ],
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
+    command: 'pnpm run dev',
     url: 'http://localhost:3000',
     reuseExistingServer: true,
     timeout: 30 * 1000,


### PR DESCRIPTION
💡 **What:** 
- Updated `playwright.config.ts` to use `pnpm run dev` instead of `npm run dev` for its webServer command.
- Removed the outdated "Playwright E2E tests fail to start or hang" troubleshooting step from `README.md`.
- Added an entry to Scribe's journal about package manager configuration alignment.

🎯 **Why:** 
The project strictly mandates the use of `pnpm`. By hardcoding `npm run dev`, Playwright tests were failing or hanging for users who correctly followed the setup instructions and did not have `npm` in their PATH.

🧠 **Cognitive Impact:** 
Fixes a first-run crash for new developers attempting to run E2E tests. By addressing the root cause in the code, we eliminate the need for a convoluted documentation workaround, making the onboarding path seamless and intuitive.

📖 **Preview:**
```typescript
  /* Run your local dev server before starting the tests */
  webServer: {
    command: 'pnpm run dev',
    url: 'http://localhost:3000',
    reuseExistingServer: true,
    timeout: 30 * 1000,
  },
```

---
*PR created automatically by Jules for task [3999969287938927294](https://jules.google.com/task/3999969287938927294) started by @fderuiter*