### PR TITLE
🛡️ Shield: Fix flaky FileReader test

### DIFF
--- a/.jules/shield.md
+++ b/.jules/shield.md
@@ -1,0 +1,3 @@
+## 2025-02-13 - Eliminate Test Flakiness from setTimeout in svgExport.test.ts
+**Discovery:** Tests relying on timers like setTimeout to trigger mock async events (e.g., `mockFileReaderInstance.onload` or `onerror`) can be flaky and non-deterministic, especially under load.
+**Defense:** Explicitly invoke mock event handlers deterministically within `act()` blocks instead of relying on setTimeout or vi.advanceTimersByTime, maintaining a direct reference to the mock instance's callback (like `onload()` or `onerror()`).

--- a/src/utils/svgExport.test.ts
+++ b/src/utils/svgExport.test.ts
@@ -199,9 +199,11 @@ describe('generateQRSvg', () => {
     // Mock FileReader to fail when readAsDataURL is called
     const originalFileReader = global.FileReader;
     class MockFileReader {
-      onerror: () => void = () => {};
+      onerror: any = null;
       readAsDataURL() {
-        setTimeout(() => this.onerror(), 0);
+        if (this.onerror) {
+          this.onerror(new Error('Mocked FileReader error'));
+        }
       }
     }
     global.FileReader = MockFileReader as any;


### PR DESCRIPTION
🛑 **Vulnerability:** The test `falls back to the original URL if FileReader fails to read blob` uses `setTimeout(() => this.onerror(), 0);` to simulate an asynchronous error in a mocked `FileReader`. This is an anti-pattern as timer-based execution can fail in load-heavy CI environments, leading to flaky, unpredictable test results.

🛡️ **Defense:** Modified the `MockFileReader` implementation to directly and deterministically invoke the `onerror` callback instead of relying on `setTimeout`. This mirrors a safer pattern already existing elsewhere in the codebase for other mocks.

🔬 **Verification:** Run `pnpm test src/utils/svgExport.test.ts` to ensure the fallback mechanism still behaves gracefully, and `pnpm test` to verify the entire test suite remains green.

📊 **Impact:** Eliminates a known source of flakiness, making the test suite more reliable and deterministic across environments.

---
*PR created automatically by Jules for task [13486035481098025135](https://jules.google.com/task/13486035481098025135) started by @fderuiter*