### PR TITLE
🧹 Polish: Refactor PatternModule to strategy pattern

### DIFF
--- a/src/components/ui/PatternModule.tsx
+++ b/src/components/ui/PatternModule.tsx
@@ -1,57 +1,42 @@
 import React from 'react';
 import { QRStyle } from '../../types';
 
+const PATTERN_RENDERERS: Partial<Record<QRStyle, React.ReactNode>> = {
+  [QRStyle.STARBURST]: (
+    <div className="flex items-center justify-center">
+      <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
+        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+      </svg>
+    </div>
+  ),
+  [QRStyle.HIVE]: (
+    <div className="flex items-center justify-center">
+      <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
+        <polygon points="50,0 100,25 100,75 50,100 0,75 0,25" />
+      </svg>
+    </div>
+  ),
+  [QRStyle.SWISS]: <div className="bg-current rounded-full" />,
+  [QRStyle.MODERN]: <div className="bg-current rounded-sm" />,
+  [QRStyle.FLUID]: <div className="bg-current rounded-full" />,
+  [QRStyle.CIRCUIT]: (
+    <div className="relative w-full h-full bg-transparent flex items-center justify-center">
+      <div className="w-1.5 h-1.5 bg-current rounded-full" />
+      <div className="absolute inset-0 border border-current opacity-50" />
+    </div>
+  ),
+  [QRStyle.GRUNGE]: (
+    <div className="flex items-center justify-center">
+      <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
+        <polygon points="10,0 100,10 90,100 0,90" />
+      </svg>
+    </div>
+  ),
+};
+
 /**
  * Helper component for rendering pattern preview modules.
  */
 export const PatternModule: React.FC<{ style: QRStyle }> = ({ style }) => {
-  if (style === QRStyle.STARBURST) {
-    return (
-      <div className="flex items-center justify-center">
-        <svg viewBox="0 0 24 24" fill="currentColor" className="w-full h-full">
-          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
-        </svg>
-      </div>
-    );
-  }
-  if (style === QRStyle.HIVE) {
-    // Hexagon
-    return (
-      <div className="flex items-center justify-center">
-        <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
-          <polygon points="50,0 100,25 100,75 50,100 0,75 0,25" />
-        </svg>
-      </div>
-    );
-  }
-  if (style === QRStyle.SWISS) {
-    return <div className="bg-current rounded-full" />;
-  }
-  if (style === QRStyle.MODERN) {
-    return <div className="bg-current rounded-sm" />;
-  }
-  if (style === QRStyle.FLUID) {
-    return <div className="bg-current rounded-full" />;
-  }
-  if (style === QRStyle.CIRCUIT) {
-    return (
-      <div className="relative w-full h-full bg-transparent flex items-center justify-center">
-        <div className="w-1.5 h-1.5 bg-current rounded-full" />
-        <div className="absolute inset-0 border border-current opacity-50" />
-      </div>
-    );
-  }
-  if (style === QRStyle.GRUNGE) {
-    return (
-      <div className="flex items-center justify-center">
-        <svg viewBox="0 0 100 100" fill="currentColor" className="w-full h-full">
-          <polygon points="10,0 100,10 90,100 0,90" />
-        </svg>
-      </div>
-    );
-  }
-  // Standard and others
-  return (
-    <div className="bg-current" />
-  );
+  return <>{PATTERN_RENDERERS[style] || <div className="bg-current" />}</>;
 };


### PR DESCRIPTION
### 💩 Smell
The `PatternModule` component contained a long sequential chain of `if` statements checking against the `QRStyle` enum. This violates the Open-Closed Principle and needlessly increases cyclomatic complexity, making it harder to read and maintain as new styles are added.

### ✨ Polish
Refactored the conditional rendering logic into a strategy pattern mapping (`PATTERN_RENDERERS`) using a `Partial<Record<QRStyle, React.ReactNode>>` dictionary lookup. 

### 📉 Reduction
Reduced cyclomatic complexity within the component from O(N) to O(1) for resolution, replacing 45+ lines of sequential branching with a clean single-line lookup and fallback.

### 🛡️ Safety
Verified with the full test suite (`pnpm test` and `pnpm lint`). Evaluating these static JSX elements at the module level is safe since they don't depend on dynamic props, maintaining exact identical behavior and rendering structure.

---
*PR created automatically by Jules for task [9149680433131223265](https://jules.google.com/task/9149680433131223265) started by @fderuiter*