### PR TITLE
🔦 Beacon: [Add internal linking to homepage via site logo]

### DIFF
--- a/src/components/QRTool.tsx
+++ b/src/components/QRTool.tsx
@@ -107,10 +107,10 @@ export default function QRTool({ initialConfig, title }: { initialConfig?: Parti
         <section aria-label="QR Code Settings" className="w-full md:w-[480px] bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-800 h-auto md:h-screen overflow-y-auto flex flex-col shadow-xl z-10 transition-colors duration-300">
           <div className="p-6 border-b border-slate-100 dark:border-slate-800 bg-white dark:bg-slate-900 sticky top-0 z-20 flex justify-between items-center transition-colors duration-300">
             <div>
-              <div className="flex items-center gap-2 text-teal-700 dark:text-teal-400 mb-1">
+              <a href="/" aria-label="QRCraftly Home" className="flex items-center gap-2 text-teal-700 dark:text-teal-400 mb-1 hover:opacity-80 transition-opacity">
                 <QrCode className="w-6 h-6" />
                 <span className="text-xl font-bold tracking-tight text-slate-700 dark:text-slate-100">{title || "QRCraftly"}</span>
-              </div>
+              </a>
               <p className="text-sm text-slate-600 dark:text-slate-400">Design beautiful QR codes in seconds.</p>
             </div>
             


### PR DESCRIPTION
🕵️ **Discovery:** The main header application logo and title in the `QRTool.tsx` component was wrapped in a static `<div>` instead of an `<a>` tag. This is a missed internal linking opportunity, preventing crawlers from easily navigating back to the root domain from deep tool pages, and creating a confusing user experience.
 
 🔦 **Signal:** Converted the `<div>` wrapper into an `<a href="/">` tag with an `aria-label="QRCraftly Home"` to provide a reliable internal link and context to screen readers.
 
 📈 **Impact:** Strengthens internal linking architecture and passes domain authority back to the home page from deep generator pages, while improving usability for humans expecting the logo to navigate home.
 
 🔬 **Verification:** Check any page (e.g., `/wifi-qr-code`) and inspect the QRCraftly logo in the top-left to ensure it uses an `<a>` tag and navigates correctly to `/`. Tests passing locally.

---
*PR created automatically by Jules for task [2889188479491288180](https://jules.google.com/task/2889188479491288180) started by @fderuiter*