### PR TITLE
🔨 Forge: Refactor Switch Statements to Strategy Pattern Maps in Renderers

### DIFF
--- a/src/utils/qr-renderers/eyes.ts
+++ b/src/utils/qr-renderers/eyes.ts
@@ -1,6 +1,99 @@
 import { QRConfig, QRStyle } from '../../types';
 import { drawRoundRect, drawPoly, drawStar, drawRoughRect, drawScribble } from '../canvasHelpers';
 
+export interface EyeRenderContext {
+    ctx: CanvasRenderingContext2D;
+    config: QRConfig;
+    x: number;
+    y: number;
+    cx: number;
+    cy: number;
+    size: number;
+    cellSize: number;
+    clearShape: (drawFn: () => void) => void;
+}
+
+type EyeRenderer = (ctxArgs: EyeRenderContext) => void;
+
+const drawRoundedEyeFrame = ({ ctx, x, y, size, cellSize, clearShape }: EyeRenderContext) => {
+    ctx.beginPath();
+    drawRoundRect(ctx, x, y, size, size, cellSize * 1.5);
+    ctx.fill();
+    clearShape(() => {
+        ctx.beginPath();
+        drawRoundRect(ctx, x + cellSize, y + cellSize, size - 2*cellSize, size - 2*cellSize, cellSize * 0.8);
+        ctx.fill();
+    });
+};
+
+const drawSquareEyeFrame = ({ ctx, x, y, size, cellSize, clearShape }: EyeRenderContext) => {
+    ctx.fillRect(x, y, size, size);
+    clearShape(() => {
+        ctx.fillRect(x + cellSize, y + cellSize, size - 2*cellSize, size - 2*cellSize);
+    });
+};
+
+const eyeRenderers: Record<QRStyle, EyeRenderer> = {
+    [QRStyle.MODERN]: (ctxArgs) => {
+        drawRoundedEyeFrame(ctxArgs);
+        ctxArgs.ctx.beginPath();
+        drawRoundRect(ctxArgs.ctx, ctxArgs.x + 2*ctxArgs.cellSize, ctxArgs.y + 2*ctxArgs.cellSize, 3*ctxArgs.cellSize, 3*ctxArgs.cellSize, ctxArgs.cellSize * 0.5);
+        ctxArgs.ctx.fill();
+    },
+    [QRStyle.SWISS]: (ctxArgs) => {
+        drawRoundedEyeFrame(ctxArgs);
+        ctxArgs.ctx.beginPath();
+        ctxArgs.ctx.arc(ctxArgs.cx, ctxArgs.cy, 1.5 * ctxArgs.cellSize, 0, Math.PI * 2);
+        ctxArgs.ctx.fill();
+    },
+    [QRStyle.FLUID]: (ctxArgs) => {
+        drawRoundedEyeFrame(ctxArgs);
+        ctxArgs.ctx.beginPath();
+        ctxArgs.ctx.arc(ctxArgs.cx, ctxArgs.cy, 1.5 * ctxArgs.cellSize, 0, Math.PI * 2);
+        ctxArgs.ctx.fill();
+    },
+    [QRStyle.CIRCUIT]: (ctxArgs) => {
+        drawSquareEyeFrame(ctxArgs);
+        ctxArgs.ctx.fillStyle = ctxArgs.config.bgColor;
+        const gap = ctxArgs.cellSize * 0.5;
+        ctxArgs.ctx.fillRect(ctxArgs.cx - gap/2, ctxArgs.y, gap, ctxArgs.cellSize * 1.1);
+        ctxArgs.ctx.fillRect(ctxArgs.cx - gap/2, ctxArgs.y + ctxArgs.size - ctxArgs.cellSize*1.1, gap, ctxArgs.cellSize*1.1);
+        ctxArgs.ctx.fillRect(ctxArgs.x, ctxArgs.cy - gap/2, ctxArgs.cellSize * 1.1, gap);
+        ctxArgs.ctx.fillRect(ctxArgs.x + ctxArgs.size - ctxArgs.cellSize*1.1, ctxArgs.cy - gap/2, ctxArgs.cellSize * 1.1, gap);
+        ctxArgs.ctx.fillStyle = ctxArgs.config.eyeColor;
+
+        ctxArgs.ctx.beginPath();
+        ctxArgs.ctx.rect(ctxArgs.x + 2*ctxArgs.cellSize, ctxArgs.y + 2*ctxArgs.cellSize, 3*ctxArgs.cellSize, 3*ctxArgs.cellSize);
+        ctxArgs.ctx.fill();
+        ctxArgs.clearShape(() => {
+            ctxArgs.ctx.fillRect(ctxArgs.x + 4.6*ctxArgs.cellSize, ctxArgs.y + 4.6*ctxArgs.cellSize, 0.4*ctxArgs.cellSize, 0.4*ctxArgs.cellSize);
+        });
+    },
+    [QRStyle.HIVE]: (ctxArgs) => {
+        drawSquareEyeFrame(ctxArgs);
+        drawPoly(ctxArgs.ctx, ctxArgs.cx, ctxArgs.cy, 1.8 * ctxArgs.cellSize, 6, 0, true);
+    },
+    [QRStyle.GRUNGE]: (ctxArgs) => {
+        drawRoughRect(ctxArgs.ctx, ctxArgs.x, ctxArgs.y, ctxArgs.size, ctxArgs.size);
+        ctxArgs.clearShape(() => {
+            ctxArgs.ctx.fillRect(ctxArgs.x + ctxArgs.cellSize, ctxArgs.y + ctxArgs.cellSize, ctxArgs.size - 2*ctxArgs.cellSize, ctxArgs.size - 2*ctxArgs.cellSize);
+        });
+        drawScribble(ctxArgs.ctx, ctxArgs.x + 2*ctxArgs.cellSize, ctxArgs.y + 2*ctxArgs.cellSize, 3*ctxArgs.cellSize);
+    },
+    [QRStyle.STARBURST]: (ctxArgs) => {
+        drawSquareEyeFrame(ctxArgs);
+        drawStar(ctxArgs.ctx, ctxArgs.cx, ctxArgs.cy, 1.9*ctxArgs.cellSize, 1.2*ctxArgs.cellSize, 5, true);
+    },
+    [QRStyle.STANDARD]: (ctxArgs) => {
+        ctxArgs.ctx.fillRect(ctxArgs.x, ctxArgs.y, ctxArgs.size, ctxArgs.size);
+        ctxArgs.clearShape(() => {
+            ctxArgs.ctx.clearRect(ctxArgs.x + ctxArgs.cellSize, ctxArgs.y + ctxArgs.cellSize, ctxArgs.size - 2*ctxArgs.cellSize, ctxArgs.size - 2*ctxArgs.cellSize);
+            ctxArgs.ctx.fillRect(ctxArgs.x + ctxArgs.cellSize, ctxArgs.y + ctxArgs.cellSize, ctxArgs.size - 2*ctxArgs.cellSize, ctxArgs.size - 2*ctxArgs.cellSize);
+        });
+        ctxArgs.ctx.fillRect(ctxArgs.x + 2*ctxArgs.cellSize, ctxArgs.y + 2*ctxArgs.cellSize, 3*ctxArgs.cellSize, 3*ctxArgs.cellSize);
+    }
+};
+
 export const renderEyes = (
     ctx: CanvasRenderingContext2D,
     config: QRConfig,
@@ -9,11 +102,10 @@ export const renderEyes = (
     cellSize: number,
     moduleCount: number
 ) => {
-    // Helper to punch hole with bgColor
     const clearShape = (drawFn: () => void) => {
         ctx.fillStyle = config.bgColor;
         drawFn();
-        ctx.fillStyle = config.eyeColor; // Restore
+        ctx.fillStyle = config.eyeColor;
     };
 
     const drawEyePattern = (r: number, c: number) => {
@@ -26,123 +118,11 @@ export const renderEyes = (
         const cx = x + size / 2;
         const cy = y + size / 2;
 
-        const drawRoundedEyeFrame = () => {
-             // Frame (Less rounded for robustness)
-             ctx.beginPath();
-             drawRoundRect(ctx, x, y, size, size, cellSize * 1.5);
-             ctx.fill();
-             // Hole
-             clearShape(() => {
-                  ctx.beginPath();
-                  drawRoundRect(ctx, x + cellSize, y + cellSize, size - 2*cellSize, size - 2*cellSize, cellSize * 0.8);
-                  ctx.fill();
-             });
-        };
-
-        const drawSquareEyeFrame = () => {
-             // Frame: Standard Square
-             ctx.fillRect(x, y, size, size);
-
-             clearShape(() => {
-                 // Standard Hole
-                 ctx.fillRect(x + cellSize, y + cellSize, size - 2*cellSize, size - 2*cellSize);
-             });
-        };
-
-        switch (config.style) {
-            case QRStyle.MODERN: // Rounded Squares
-                drawRoundedEyeFrame();
-
-                // Eyeball (Solid Square with slight rounding)
-                ctx.beginPath();
-                drawRoundRect(ctx, x + 2*cellSize, y + 2*cellSize, 3*cellSize, 3*cellSize, cellSize * 0.5);
-                ctx.fill();
-                break;
-
-            case QRStyle.SWISS: // Swiss Dot
-                drawRoundedEyeFrame();
-
-                // Eyeball: Floating Dot (Circular)
-                ctx.beginPath();
-                // Standard Radius 1.5 (Diameter 3)
-                ctx.arc(cx, cy, 1.5 * cellSize, 0, Math.PI * 2);
-                ctx.fill();
-                break;
-
-            case QRStyle.FLUID: // Fluid
-                // COPY OF SWISS (Proven to pass)
-                drawRoundedEyeFrame();
-
-                // Eyeball: Circular (Same as Swiss)
-                ctx.beginPath();
-                ctx.arc(cx, cy, 1.5 * cellSize, 0, Math.PI * 2);
-                ctx.fill();
-                break;
-
-            case QRStyle.CIRCUIT: // Cyber-Circuit (Brackets + Notched)
-                 drawSquareEyeFrame();
-
-                 // Simulate brackets by drawing small white lines over the frame
-                 ctx.fillStyle = config.bgColor;
-                 const gap = cellSize * 0.5;
-                 ctx.fillRect(cx - gap/2, y, gap, cellSize * 1.1); // Top cut
-                 ctx.fillRect(cx - gap/2, y + size - cellSize*1.1, gap, cellSize*1.1); // Bottom cut
-                 ctx.fillRect(x, cy - gap/2, cellSize * 1.1, gap); // Left cut
-                 ctx.fillRect(x + size - cellSize*1.1, cy - gap/2, cellSize * 1.1, gap); // Right cut
-                 ctx.fillStyle = config.eyeColor;
-
-                 // Eyeball: Notched Square
-                 ctx.beginPath();
-                 // Standard 3x3 square
-                 ctx.rect(x + 2*cellSize, y + 2*cellSize, 3*cellSize, 3*cellSize);
-                 ctx.fill();
-                 // Add slight notch via clearing
-                 clearShape(() => {
-                    ctx.fillRect(x + 4.6*cellSize, y + 4.6*cellSize, 0.4*cellSize, 0.4*cellSize);
-                 });
-                 break;
-
-            case QRStyle.HIVE: // Hexagon
-                drawSquareEyeFrame();
-
-                // Eyeball: Solid Hex (This is fine usually if large enough)
-                drawPoly(ctx, cx, cy, 1.8 * cellSize, 6, 0, true);
-                break;
-
-            case QRStyle.GRUNGE: // Grunge
-                // Frame
-                drawRoughRect(ctx, x, y, size, size);
-
-                clearShape(() => {
-                    ctx.fillRect(x + cellSize, y + cellSize, size - 2*cellSize, size - 2*cellSize);
-                });
-
-                // Eyeball - Solid rough polygon
-                drawScribble(ctx, x + 2*cellSize, y + 2*cellSize, 3*cellSize);
-                break;
-
-            case QRStyle.STARBURST:
-                 drawSquareEyeFrame();
-
-                 // Eyeball: Star
-                 // Make it fat
-                 drawStar(ctx, cx, cy, 1.9*cellSize, 1.2*cellSize, 5, true);
-                 break;
-
-            case QRStyle.STANDARD:
-            default:
-                // Standard
-                ctx.fillRect(x, y, size, size);
-                clearShape(() => {
-                     ctx.clearRect(x + cellSize, y + cellSize, size - 2*cellSize, size - 2*cellSize);
-                     ctx.fillRect(x + cellSize, y + cellSize, size - 2*cellSize, size - 2*cellSize);
-                });
-                ctx.fillRect(x + 2*cellSize, y + 2*cellSize, 3*cellSize, 3*cellSize);
-                break;
-        }
+        const ctxArgs: EyeRenderContext = { ctx, config, x, y, cx, cy, size, cellSize, clearShape };
+        const renderer = eyeRenderers[config.style] || eyeRenderers[QRStyle.STANDARD];
+        renderer(ctxArgs);
     };
 
-    // Draw Eyes (Last to ensure they overlap nicely if needed)
     drawEyePattern(0, 0);
     drawEyePattern(0, moduleCount - 7);
     drawEyePattern(moduleCount - 7, 0);

--- a/src/utils/qr-renderers/modules.ts
+++ b/src/utils/qr-renderers/modules.ts
@@ -4,6 +4,152 @@ import { getIsCoveredByLogo, LogoMetrics } from './utils';
 
 type DrawModuleFn = (r: number, c: number, x: number, y: number, cx: number, cy: number) => void;
 
+type ModuleDrawerFactory = (
+    ctx: CanvasRenderingContext2D,
+    cellSize: number,
+    modules: QRModules,
+    moduleCount: number,
+    isCoveredByLogo: (r: number, c: number) => boolean
+) => DrawModuleFn;
+
+const moduleDrawerStrategies: Record<QRStyle, ModuleDrawerFactory> = {
+    [QRStyle.MODERN]: (ctx, cellSize) => {
+        const rModern = cellSize * 0.3;
+        return (_r, _c, x, y, _cx, _cy) => drawRoundRect(ctx, x, y, cellSize, cellSize, rModern);
+    },
+    [QRStyle.SWISS]: (ctx, cellSize) => {
+        const rSwiss = (cellSize / 2) * 1.05;
+        return (_r, _c, _x, _y, cx, cy) => {
+            ctx.moveTo(cx + rSwiss, cy);
+            ctx.arc(cx, cy, rSwiss, 0, Math.PI*2);
+        };
+    },
+    [QRStyle.FLUID]: (ctx, cellSize) => {
+        const rFluid = (cellSize / 2) * 1.1;
+        return (_r, _c, _x, _y, cx, cy) => {
+            ctx.moveTo(cx + rFluid, cy);
+            ctx.arc(cx, cy, rFluid, 0, Math.PI*2);
+        };
+    },
+    [QRStyle.CIRCUIT]: (ctx, cellSize, modules, moduleCount, isCoveredByLogo) => {
+        // Optimization: Apply section-splitting to skip known dead zones (eyes) entirely.
+        // This avoids calling isEye() inside the loop for every module and uses flat 1D indexing.
+        const validGrid = new Uint8Array(moduleCount * moduleCount);
+
+        for (let r = 0; r < 7; r++) {
+            const rowOffset = r * moduleCount;
+            for (let c = 7; c < moduleCount - 7; c++) {
+                if (modules.get(r, c) && !isCoveredByLogo(r, c)) {
+                    validGrid[rowOffset + c] = 1;
+                }
+            }
+        }
+
+        for (let r = 7; r < moduleCount - 7; r++) {
+            const rowOffset = r * moduleCount;
+            for (let c = 0; c < moduleCount; c++) {
+                if (modules.get(r, c) && !isCoveredByLogo(r, c)) {
+                    validGrid[rowOffset + c] = 1;
+                }
+            }
+        }
+
+        for (let r = moduleCount - 7; r < moduleCount; r++) {
+            const rowOffset = r * moduleCount;
+            for (let c = 7; c < moduleCount; c++) {
+                if (modules.get(r, c) && !isCoveredByLogo(r, c)) {
+                    validGrid[rowOffset + c] = 1;
+                }
+            }
+        }
+
+        const rCircuit = cellSize * 0.1;
+        const thickness = cellSize * 0.4;
+        const thicknessHalf = thickness / 2;
+        const linkLen = cellSize / 2 + 1;
+
+        return (r, c, x, y, cx, cy) => {
+            const idx = r * moduleCount + c;
+            const hasTop = r > 0 && validGrid[idx - moduleCount];
+            const hasBottom = r < moduleCount-1 && validGrid[idx + moduleCount];
+            const hasLeft = c > 0 && validGrid[idx - 1];
+            const hasRight = c < moduleCount-1 && validGrid[idx + 1];
+
+            drawRoundRect(ctx, x, y, cellSize, cellSize, rCircuit);
+
+            if (hasRight) ctx.rect(cx, cy - thicknessHalf, linkLen, thickness);
+            if (hasBottom) ctx.rect(cx - thicknessHalf, cy, thickness, linkLen);
+            if (hasLeft) ctx.rect(x, cy - thicknessHalf, linkLen, thickness);
+            if (hasTop) ctx.rect(cx - thicknessHalf, y, thickness, linkLen);
+        };
+    },
+    [QRStyle.HIVE]: (ctx, cellSize) => {
+        // Optimization: Pre-calculate hexagon offsets using a flat Float64Array
+        // instead of objects or nested arrays. This improves performance in the
+        // hot rendering loop by avoiding object allocations and taking advantage
+        // of continuous memory, without sacrificing readability.
+        const rHive = cellSize / 1.55;
+        const sidesHive = 6;
+
+        const offsets = new Float64Array(sidesHive * 2);
+        for (let i = 0; i < sidesHive; i++) {
+            const theta = (i * 2 * Math.PI) / sidesHive;
+            offsets[i * 2] = rHive * Math.cos(theta);
+            offsets[i * 2 + 1] = rHive * Math.sin(theta);
+        }
+
+        return (_r, _c, _x, _y, cx, cy) => {
+            ctx.moveTo(cx + offsets[0], cy + offsets[1]);
+            for (let i = 1; i < sidesHive; i++) {
+                ctx.lineTo(cx + offsets[i * 2], cy + offsets[i * 2 + 1]);
+            }
+            ctx.closePath();
+        };
+    },
+    [QRStyle.GRUNGE]: (ctx, cellSize) => {
+        return (_r, _c, x, y, _cx, _cy) => drawRoughRect(ctx, x, y, cellSize, cellSize, true);
+    },
+    [QRStyle.STARBURST]: (ctx, cellSize) => {
+        // Optimization: Pre-calculate starburst offsets using a flat Float64Array
+        // instead of an array of objects. This improves performance in the hot
+        // rendering loop by avoiding object allocations while maintaining clean loops.
+        const outerR = cellSize / 1.5;
+        const innerR = cellSize / 2.2;
+        const spikes = 5;
+        const step = Math.PI / spikes;
+
+        const offsets = new Float64Array(spikes * 4);
+        let rot = Math.PI / 2 * 3;
+
+        for (let i = 0; i < spikes; i++) {
+            const baseIdx = i * 4;
+            offsets[baseIdx] = Math.cos(rot) * outerR;
+            offsets[baseIdx + 1] = Math.sin(rot) * outerR;
+            rot += step;
+
+            offsets[baseIdx + 2] = Math.cos(rot) * innerR;
+            offsets[baseIdx + 3] = Math.sin(rot) * innerR;
+            rot += step;
+        }
+
+        return (_r, _c, _x, _y, cx, cy) => {
+            ctx.moveTo(cx, cy - outerR);
+            for (let i = 0; i < offsets.length; i += 2) {
+                ctx.lineTo(cx + offsets[i], cy + offsets[i + 1]);
+            }
+            ctx.lineTo(cx, cy - outerR);
+            ctx.closePath();
+        };
+    },
+    [QRStyle.STANDARD]: (ctx, cellSize) => {
+        // Optimization: Pre-calculate Math.ceil(cellSize) outside the inner rendering loop
+        // to avoid redundant math operations for every drawn module.
+        // Performance impact: Reduces execution time of STANDARD style rendering loop.
+        const ceilCellSize = Math.ceil(cellSize);
+        return (_r, _c, x, y, _cx, _cy) => ctx.rect(Math.floor(x), Math.floor(y), ceilCellSize, ceilCellSize);
+    }
+};
+
 const getModuleDrawer = (
     style: QRStyle,
     ctx: CanvasRenderingContext2D,
@@ -12,153 +158,8 @@ const getModuleDrawer = (
     moduleCount: number,
     isCoveredByLogo: (r: number, c: number) => boolean
 ): DrawModuleFn => {
-    switch(style) {
-        case QRStyle.MODERN: {
-            const rModern = cellSize * 0.3;
-            return (_r, _c, x, y, _cx, _cy) => drawRoundRect(ctx, x, y, cellSize, cellSize, rModern);
-        }
-        case QRStyle.SWISS: {
-            const rSwiss = (cellSize / 2) * 1.05;
-            return (_r, _c, _x, _y, cx, cy) => {
-                ctx.moveTo(cx + rSwiss, cy);
-                ctx.arc(cx, cy, rSwiss, 0, Math.PI*2);
-            };
-        }
-        case QRStyle.FLUID: {
-            const rFluid = (cellSize / 2) * 1.1;
-            return (_r, _c, _x, _y, cx, cy) => {
-                ctx.moveTo(cx + rFluid, cy);
-                ctx.arc(cx, cy, rFluid, 0, Math.PI*2);
-            };
-        }
-        case QRStyle.CIRCUIT: {
-            // Pre-calculate valid modules for CIRCUIT style to avoid repeated expensive checks
-            // (isCoveredByLogo and isEye) for every neighbor of every module.
-            const validGrid = new Uint8Array(moduleCount * moduleCount);
-
-            // Optimization: Apply section-splitting to skip known dead zones (eyes) entirely.
-            // This avoids calling isEye() inside the loop for every module and uses flat 1D indexing.
-
-            // Top Section (Rows 0-6): Skip TL (0-6) and TR (size-7 to size-1)
-            for (let r = 0; r < 7; r++) {
-                const rowOffset = r * moduleCount;
-                for (let c = 7; c < moduleCount - 7; c++) {
-                    if (modules.get(r, c) && !isCoveredByLogo(r, c)) {
-                        validGrid[rowOffset + c] = 1;
-                    }
-                }
-            }
-
-            // Middle Section (Rows 7 to size-8): No eyes
-            for (let r = 7; r < moduleCount - 7; r++) {
-                const rowOffset = r * moduleCount;
-                for (let c = 0; c < moduleCount; c++) {
-                    if (modules.get(r, c) && !isCoveredByLogo(r, c)) {
-                        validGrid[rowOffset + c] = 1;
-                    }
-                }
-            }
-
-            // Bottom Section (Rows size-7 to size-1): Skip BL (0-6)
-            for (let r = moduleCount - 7; r < moduleCount; r++) {
-                const rowOffset = r * moduleCount;
-                for (let c = 7; c < moduleCount; c++) {
-                    if (modules.get(r, c) && !isCoveredByLogo(r, c)) {
-                        validGrid[rowOffset + c] = 1;
-                    }
-                }
-            }
-
-            // Pre-calculate dimensional constants
-            const rCircuit = cellSize * 0.1;
-            const thickness = cellSize * 0.4;
-            const thicknessHalf = thickness / 2;
-            const linkLen = cellSize / 2 + 1;
-
-            return (r, c, x, y, cx, cy) => {
-                // Optimization: use flat 1D indexing to check neighbors
-                const idx = r * moduleCount + c;
-                const hasTop = r > 0 && validGrid[idx - moduleCount];
-                const hasBottom = r < moduleCount-1 && validGrid[idx + moduleCount];
-                const hasLeft = c > 0 && validGrid[idx - 1];
-                const hasRight = c < moduleCount-1 && validGrid[idx + 1];
-
-                // Full square with very tiny notches
-                drawRoundRect(ctx, x, y, cellSize, cellSize, rCircuit);
-
-                // Draw lines to neighbors
-                if (hasRight) ctx.rect(cx, cy - thicknessHalf, linkLen, thickness);
-                if (hasBottom) ctx.rect(cx - thicknessHalf, cy, thickness, linkLen);
-                if (hasLeft) ctx.rect(x, cy - thicknessHalf, linkLen, thickness);
-                if (hasTop) ctx.rect(cx - thicknessHalf, y, thickness, linkLen);
-            };
-        }
-        case QRStyle.HIVE: {
-            // Optimization: Pre-calculate hexagon offsets using a flat Float64Array
-            // instead of objects or nested arrays. This improves performance in the
-            // hot rendering loop by avoiding object allocations and taking advantage
-            // of continuous memory, without sacrificing readability.
-            const rHive = cellSize / 1.55;
-            const sidesHive = 6;
-
-            const offsets = new Float64Array(sidesHive * 2);
-            for (let i = 0; i < sidesHive; i++) {
-                const theta = (i * 2 * Math.PI) / sidesHive;
-                offsets[i * 2] = rHive * Math.cos(theta);
-                offsets[i * 2 + 1] = rHive * Math.sin(theta);
-            }
-
-            return (_r, _c, _x, _y, cx, cy) => {
-                ctx.moveTo(cx + offsets[0], cy + offsets[1]);
-                for (let i = 1; i < sidesHive; i++) {
-                    ctx.lineTo(cx + offsets[i * 2], cy + offsets[i * 2 + 1]);
-                }
-                ctx.closePath();
-            };
-        }
-        case QRStyle.GRUNGE:
-            return (_r, _c, x, y, _cx, _cy) => drawRoughRect(ctx, x, y, cellSize, cellSize, true);
-        case QRStyle.STARBURST: {
-            // Optimization: Pre-calculate starburst offsets using a flat Float64Array
-            // instead of an array of objects. This improves performance in the hot
-            // rendering loop by avoiding object allocations while maintaining clean loops.
-            const outerR = cellSize / 1.5;
-            const innerR = cellSize / 2.2;
-            const spikes = 5;
-            const step = Math.PI / spikes;
-
-            const offsets = new Float64Array(spikes * 4); // 2 points per spike, 2 coords per point
-            let rot = Math.PI / 2 * 3;
-
-            for (let i = 0; i < spikes; i++) {
-                const baseIdx = i * 4;
-                offsets[baseIdx] = Math.cos(rot) * outerR;
-                offsets[baseIdx + 1] = Math.sin(rot) * outerR;
-                rot += step;
-
-                offsets[baseIdx + 2] = Math.cos(rot) * innerR;
-                offsets[baseIdx + 3] = Math.sin(rot) * innerR;
-                rot += step;
-            }
-
-            return (_r, _c, _x, _y, cx, cy) => {
-                ctx.moveTo(cx, cy - outerR);
-                for (let i = 0; i < offsets.length; i += 2) {
-                    ctx.lineTo(cx + offsets[i], cy + offsets[i + 1]);
-                }
-                ctx.lineTo(cx, cy - outerR);
-                ctx.closePath();
-            };
-        }
-        case QRStyle.STANDARD:
-        default: {
-            // Optimization: Pre-calculate Math.ceil(cellSize) outside the inner rendering loop
-            // to avoid redundant math operations for every drawn module.
-            // Performance impact: Reduces execution time of STANDARD style rendering loop.
-            const ceilCellSize = Math.ceil(cellSize);
-            return (_r, _c, x, y, _cx, _cy) => ctx.rect(Math.floor(x), Math.floor(y), ceilCellSize, ceilCellSize);
-        }
-    }
+    const factory = moduleDrawerStrategies[style] || moduleDrawerStrategies[QRStyle.STANDARD];
+    return factory(ctx, cellSize, modules, moduleCount, isCoveredByLogo);
 };
 
 export const renderModules = (

--- a/src/utils/templateRenderer.ts
+++ b/src/utils/templateRenderer.ts
@@ -221,6 +221,20 @@ function drawTemplateText(
  * @param displayHeight Logical display height in px.
  * @param moduleCount   Number of QR modules per row/column.
  */
+type BackgroundRenderer = (
+  ctx: CanvasRenderingContext2D,
+  config: QRConfig,
+  width: number,
+  height: number
+) => void;
+
+const backgroundRenderers: Record<TemplateStyle, BackgroundRenderer> = {
+  [TemplateStyle.NONE]: drawNoneBackground,
+  [TemplateStyle.MINIMALIST]: drawMinimalistBackground,
+  [TemplateStyle.GRADIENT_BLUR]: drawGradientBlurBackground,
+  [TemplateStyle.SOLID_FRAME]: drawSolidFrameBackground,
+};
+
 export function drawWithTemplate(
   ctx: CanvasRenderingContext2D,
   modules: QRModules,
@@ -234,19 +248,8 @@ export function drawWithTemplate(
   ctx.clearRect(0, 0, displayWidth, displayHeight);
 
   // ── 1. Background ──────────────────────────────────────────────────────────
-  switch (config.templateStyle) {
-    case TemplateStyle.MINIMALIST:
-      drawMinimalistBackground(ctx, config, displayWidth, displayHeight);
-      break;
-    case TemplateStyle.GRADIENT_BLUR:
-      drawGradientBlurBackground(ctx, config, displayWidth, displayHeight);
-      break;
-    case TemplateStyle.SOLID_FRAME:
-      drawSolidFrameBackground(ctx, config, displayWidth, displayHeight);
-      break;
-    default:
-      drawNoneBackground(ctx, config, displayWidth, displayHeight);
-  }
+  const renderer = backgroundRenderers[config.templateStyle] || backgroundRenderers[TemplateStyle.NONE];
+  renderer(ctx, config, displayWidth, displayHeight);
 
   // ── 2. QR Bounding-Box ────────────────────────────────────────────────────
   // For NONE template on a square canvas the QR fills 100 % so it looks


### PR DESCRIPTION
🛑 **The Smell:** 
Rendering logic for QR modules, eyes, and templates relied on bloated `switch` statements matching on enums (`QRStyle`, `TemplateStyle`). This violated the Open/Closed Principle; every new style added to the application required modifying these core rendering switch blocks, increasing cyclomatic complexity and the risk of regressions.

🔨 **The Fix:** 
Extracted the conditional logic into Strategy Pattern maps (Record/dictionary lookups).
- `modules.ts`: Replaced the `switch` with a `moduleDrawerStrategies` map.
- `eyes.ts`: Replaced the `switch` with an `eyeRenderers` map and introduced an `EyeRenderContext` to neatly pass dependencies.
- `templateRenderer.ts`: Replaced the `switch` with a `backgroundRenderers` map.

🧠 **The Why:** 
Decoupling the mapping logic makes the code more scalable. Future developers can simply add a new key-value pair to the dictionary when introducing a new `QRStyle` without touching the core rendering iteration loop. This significantly reduces cognitive load by eliminating massive `switch` blocks.

⚠️ **Risk:** 
Low - pure structural refactor. The output behavior is identical, type checker passes strictly, and all 469 Vitest rendering and benchmark tests pass successfully.

---
*PR created automatically by Jules for task [7388789003745339320](https://jules.google.com/task/7388789003745339320) started by @fderuiter*