### PR TITLE
🎨 Palette: Add helpful placeholders to contact and SMS inputs

### DIFF
--- a/src/components/inputs/SmsInput.tsx
+++ b/src/components/inputs/SmsInput.tsx
@@ -26,6 +26,7 @@ export const SmsInput: React.FC<SmsInputProps> = ({ data, onChange }) => {
         label="Pre-filled Message"
         rows={3}
         maxLength={1600}
+        placeholder="Type your SMS message here..."
         value={data.message}
         onChange={(e) => onChange({ message: e.target.value })}
         showCharCount

--- a/src/components/inputs/VCardInput.tsx
+++ b/src/components/inputs/VCardInput.tsx
@@ -20,6 +20,7 @@ export const VCardInput: React.FC<VCardInputProps> = ({ data, onChange }) => {
           label="First Name"
           autoComplete="given-name"
           maxLength={100}
+          placeholder="e.g. Jane"
           value={data.firstName}
           onChange={(e) => onChange({ firstName: e.target.value })}
         />
@@ -29,6 +30,7 @@ export const VCardInput: React.FC<VCardInputProps> = ({ data, onChange }) => {
           label="Last Name"
           autoComplete="family-name"
           maxLength={100}
+          placeholder="e.g. Doe"
           value={data.lastName}
           onChange={(e) => onChange({ lastName: e.target.value })}
         />
@@ -42,6 +44,7 @@ export const VCardInput: React.FC<VCardInputProps> = ({ data, onChange }) => {
           autoComplete="tel"
           type="tel"
           maxLength={20}
+          placeholder="+1 555 000 0000"
           value={data.phone}
           onChange={(e) => onChange({ phone: e.target.value })}
         />
@@ -52,6 +55,7 @@ export const VCardInput: React.FC<VCardInputProps> = ({ data, onChange }) => {
           autoComplete="email"
           type="email"
           maxLength={254}
+          placeholder="name@example.com"
           value={data.email}
           onChange={(e) => onChange({ email: e.target.value })}
         />
@@ -63,6 +67,7 @@ export const VCardInput: React.FC<VCardInputProps> = ({ data, onChange }) => {
         label="Company / Organization"
         autoComplete="organization"
         maxLength={100}
+        placeholder="e.g. Acme Corp"
         value={data.organization}
         onChange={(e) => onChange({ organization: e.target.value })}
       />
@@ -73,6 +78,7 @@ export const VCardInput: React.FC<VCardInputProps> = ({ data, onChange }) => {
         label="Job Title"
         autoComplete="organization-title"
         maxLength={100}
+        placeholder="e.g. Software Engineer"
         value={data.title}
         onChange={(e) => onChange({ title: e.target.value })}
       />
@@ -84,6 +90,7 @@ export const VCardInput: React.FC<VCardInputProps> = ({ data, onChange }) => {
         autoComplete="url"
         type="url"
         maxLength={2048}
+        placeholder="https://example.com"
         value={data.website}
         onChange={(e) => onChange({ website: e.target.value })}
       />


### PR DESCRIPTION
### 💡 What
Added descriptive `placeholder` attributes to the text inputs in `VCardInput.tsx` and `SmsInput.tsx`.

### 🎯 Why
Empty form fields can cause user hesitation, especially for complex formats like vCards. Providing clear examples (e.g., `e.g. Jane`, `+1 555 000 0000`, `name@example.com`) directly in the inputs improves form intuitiveness and guides users on expected data formats. This reduces cognitive load and makes the interaction feel smoother.

### 📸 Before/After
*   **Before:** vCard inputs and SMS message inputs were blank when empty, leaving users to guess the expected format.
*   **After:** Inputs now show helpful, light-grey examples of what should be typed.

### ♿ Accessibility
Improves overall usability and cognitive accessibility by clearly demonstrating expected input formats, reducing the need to rely solely on field labels.

---
*PR created automatically by Jules for task [7651893464089063460](https://jules.google.com/task/7651893464089063460) started by @fderuiter*