### PR TITLE
Fix GHA schema validation error in main.yml deploy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -275,7 +275,6 @@ jobs:
     name: Deploy
     needs: [static-validation, test, e2e, build]
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Revert'))
-    timeout-minutes: 15
     concurrency:
       group: production-deployment
       cancel-in-progress: false


### PR DESCRIPTION
This pull request resolves a GitHub Actions schema validation error in the CI/CD pipeline. 

By removing the `timeout-minutes` property from the caller `deploy` job in `.github/workflows/main.yml`, the YAML parser can correctly parse it as a reusable workflow call rather than a standard job that expects a `runs-on` property. The `timeout-minutes: 15` restriction is already correctly present within the called reusable workflow (`.github/workflows/deploy.yml`).

Fixes #756

---
*PR created automatically by Jules for task [12601428791471220869](https://jules.google.com/task/12601428791471220869) started by @fderuiter*