### PR TITLE
fix: remove invalid repository_ruleset trigger from scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,7 +1,6 @@
 name: Scorecard supply-chain security
 on:
   branch_protection_rule:
-  repository_ruleset:
   schedule:
     - cron: '30 1 * * 6'
   push:


### PR DESCRIPTION
The OSSF Scorecard workflow configuration was failing to load due to an invalid event trigger key: repository_ruleset. Removing this key restores workflow validity while preserving the remaining OSSF Scorecard recommended settings.

Fixes #757

---
*PR created automatically by Jules for task [3353285911775916305](https://jules.google.com/task/3353285911775916305) started by @fderuiter*