### PR TITLE
Keep QR scanner video mounted during camera initialization

### DIFF
--- a/src/components/QRScanner.test.tsx
+++ b/src/components/QRScanner.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { QRScanner } from './QRScanner';
 import { useCamera } from '../hooks/useCamera';
@@ -95,6 +95,44 @@ describe('QRScanner Component', () => {
 
     expect(screen.getByRole('button', { name: /webcam/i })).toHaveClass('bg-white');
     expect(mockStartStream).toHaveBeenCalled();
+  });
+
+  it('keeps the video mounted while camera permission is initializing', async () => {
+    let resolveStream: (stream: MediaStream) => void = () => {};
+    const streamPromise = new Promise<MediaStream>((resolve) => {
+      resolveStream = resolve;
+    });
+    mockStartStream.mockReturnValue(streamPromise);
+
+    let isInitializing = false;
+    vi.mocked(useCamera).mockImplementation(() => ({
+      permissionState: 'prompt',
+      stream: null,
+      error: null,
+      isInitializing,
+      startStream: mockStartStream,
+      stopStream: mockStopStream,
+    }));
+
+    const { rerender } = render(
+      <QRScanner onScanSuccess={mockOnScanSuccess} onClose={mockOnClose} />
+    );
+    const video = screen.getByLabelText('Webcam feed') as HTMLVideoElement;
+
+    isInitializing = true;
+    rerender(<QRScanner onScanSuccess={mockOnScanSuccess} onClose={mockOnClose} />);
+
+    expect(screen.getByLabelText('Webcam feed')).toBe(video);
+    expect(screen.getByText('Initializing camera stream...')).toBeInTheDocument();
+
+    const activeStream = { getTracks: () => [] } as unknown as MediaStream;
+    await act(async () => {
+      resolveStream(activeStream);
+      await streamPromise;
+    });
+
+    expect(video.srcObject).toBe(activeStream);
+    expect(mockStartScanning).toHaveBeenCalled();
   });
 
   it('renders troubleshooting card immediately upon camera permission denial', async () => {

--- a/src/components/QRScanner.tsx
+++ b/src/components/QRScanner.tsx
@@ -683,15 +683,6 @@ export const QRScanner: React.FC<QRScannerProps> = ({ onScanSuccess, onClose, co
 
   // Render webcam viewfinder state
   const renderWebcamViewfinder = () => {
-    if (isInitializing) {
-      return (
-        <div className="flex flex-col items-center justify-center p-6 text-slate-500 dark:text-slate-400">
-          <RefreshCw className="mb-3 size-8 animate-spin text-teal-600 dark:text-teal-400" />
-          <p className="text-sm font-medium">Initializing camera stream...</p>
-        </div>
-      );
-    }
-
     if (permissionState === 'denied' || permissionState === 'unavailable') {
       return (
         <div className="flex size-full flex-col justify-between p-5 text-center text-slate-800 dark:text-slate-200">
@@ -726,10 +717,17 @@ export const QRScanner: React.FC<QRScannerProps> = ({ onScanSuccess, onClose, co
         <video
           ref={videoRef}
           className="size-full object-cover"
+          autoPlay
           playsInline
           muted
           aria-label="Webcam feed"
         />
+        {isInitializing && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/60 p-6 text-white">
+            <RefreshCw className="mb-3 size-8 animate-spin text-teal-400" />
+            <p className="text-sm font-medium">Initializing camera stream...</p>
+          </div>
+        )}
         {/* Scanning targeting guide overlay */}
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center border-[3px] border-teal-500/40">
           <div className="relative flex size-48 animate-pulse items-center justify-center rounded-lg border-2 border-teal-400">


### PR DESCRIPTION
## Summary
- Keep the webcam video element mounted while camera permissions and stream initialization are in progress.
- Show the initialization state as an overlay so the video can attach the stream without remounting.
- Enable autoplay for the webcam feed.
- Add regression coverage for delayed stream initialization and scanning startup.

## Testing
- Added and updated Vitest/React Testing Library coverage for the initialization flow.